### PR TITLE
Update path for QC DPL dump

### DIFF
--- a/workflows/readout-qc.yaml
+++ b/workflows/readout-qc.yaml
@@ -28,7 +28,7 @@ roles:
   - name: qc-single-subwf
     defaults:
       qchost: "{{ FromJson(hosts)[0] }}"
-      dpl_config: "/home/flp/stfb-qc.dpl.json"
+      dpl_config: "/etc/flp.d/qc/stfb-qc.dpl.json"
     constraints:
       - attribute: machine_id
         value: "{{ qchost }}"


### PR DESCRIPTION
The QC DPL dump configuration is now stored in a new path.