### PR TITLE
[OCTLR-317] Add gh action walnut

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - 'feature/OCTRL-317-add-gh-action-walnut'
-      - 'dev'
+      - 'master'
 
 jobs:
   tasks-check:
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
             path: ControlWorkflows
-            ref: 'flp-suite-v0.10.0'
       - uses: actions/setup-go@v2
         with:
           # go-version: ${{matrix.go}}
@@ -35,6 +34,7 @@ jobs:
           path: Control
       - run: (cd Control; make vendor)
       - run: (cd Control; make)
+      - run: (echo "Checks will be ran against branch  ${{ github.ref }}")
       - name: Run Walnut checks for TASKS
         working-directory: ./Control
         run: |

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run Walnut checks for tasks
         working-directory: ./Control
         run: |
-          for file in ./../ControlWorkflows/{{ matrix.tasks }}/*.yml; do
-            echo "Walnut will check file ${file} in folder ${{ matrix.tasks }}"
+          for file in ./../ControlWorkflows/{{ matrix.checkDirectories }}/*.yml; do
+            echo "Walnut will check file ${file} in folder ${{ matrix.checkDirectories }}"
           done
 
   # workflow-check:

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -15,10 +15,10 @@ jobs:
     name: Check Tasks Templates through Walnut
     # runs-on: ${{ matrix.os }}
     runs-on: macOS-latest
-    strategy:
-      matrix:
-        os: [macOS-latest, ubuntu-18.04]
-        go: [ '1.14.7', '1.15.0' ]
+    # strategy:
+    #   matrix:
+    #     os: [macOS-latest, ubuntu-18.04]
+    #     go: [ '1.14.7', '1.15.0' ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,37 +13,42 @@ on:
 jobs:
   tasks-check:
     name: Check Tasks Templates through Walnut
-    runs-on: ${{ matrix.os }}
+    # runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-18.04]
         go: [ '1.14.7', '1.15.0' ]
     steps:
       - uses: actions/checkout@v2
+        with:
+            path: ControlWorkflows
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{matrix.go}}
+          # go-version: ${{matrix.go}}
+          go-version: '1.15.0'
       - uses: actions/checkout@v2
         with: 
           repository: AliceO2Group/Control
           ref: 'master'
+          path: Control
       - run: (cd Control; echo "In Control now")
       - run: (cd ControlWorkflows; echo "In ControlWorfklows now")
-  workflow-check:
-        name: Check Workflow Templates through Walnut
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [macOS-latest, ubuntu-18.04]
-            go: [ '1.14.7', '1.15.0' ]
-        steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-go@v2
-            with:
-              go-version: ${{matrix.go}}
-          - uses: actions/checkout@v2
-            with: 
-              repository: AliceO2Group/Control
-              ref: 'master'
-          - run: (cd Control; echo "In Control now")
-          - run: (cd ControlWorkflows; echo "In ControlWorfklows now")
+  # workflow-check:
+  #       name: Check Workflow Templates through Walnut
+  #       runs-on: ${{ matrix.os }}
+  #       strategy:
+  #         matrix:
+  #           os: [macOS-latest, ubuntu-18.04]
+  #           go: [ '1.14.7', '1.15.0' ]
+  #       steps:
+  #         - uses: actions/checkout@v2
+  #         - uses: actions/setup-go@v2
+  #           with:
+  #             go-version: ${{matrix.go}}
+  #         - uses: actions/checkout@v2
+  #           with: 
+  #             repository: AliceO2Group/Control
+  #             ref: 'master'
+  #         - run: (cd Control; echo "In Control now")
+  #         - run: (cd ControlWorkflows; echo "In ControlWorfklows now")

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -1,0 +1,49 @@
+name: WalnutChecks
+on:
+  pull_request:
+    paths:
+      - 'tasks/*'
+      - 'workflows/*'
+      - '.github/workflows/template.yml'
+  push:
+    branches:
+      - 'feature/OCTRL-317-add-gh-action-walnut'
+      - 'dev'
+
+jobs:
+  tasks-check:
+    name: Check Tasks Templates through Walnut
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-18.04]
+        go: [ '1.14.7', '1.15.0' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{matrix.go}}
+      - uses: actions/checkout@v2
+        with: 
+          repository: AliceO2Group/Control
+          ref: 'master'
+      - run: (cd Control; echo "In Control now")
+      - run: (cd ControlWorkflows; echo "In ControlWorfklows now")
+  workflow-check:
+        name: Check Workflow Templates through Walnut
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [macOS-latest, ubuntu-18.04]
+            go: [ '1.14.7', '1.15.0' ]
+        steps:
+          - uses: actions/checkout@v2
+          - uses: actions/setup-go@v2
+            with:
+              go-version: ${{matrix.go}}
+          - uses: actions/checkout@v2
+            with: 
+              repository: AliceO2Group/Control
+              ref: 'master'
+          - run: (cd Control; echo "In Control now")
+          - run: (cd ControlWorkflows; echo "In ControlWorfklows now")

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
     #     os: [macOS-latest, ubuntu-18.04]
     #     go: [ '1.14.7', '1.15.0' ]
-          checkDirectories: ['tasks', 'workflows']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -38,8 +37,8 @@ jobs:
       - name: Run Walnut checks for tasks
         working-directory: ./Control
         run: |
-          for file in ./../ControlWorkflows/{{ matrix.checkDirectories }}/*.yml; do
-            echo "Walnut will check file ${file} in folder ${{ matrix.checkDirectories }}"
+          for file in ./../ControlWorkflows/tasks/*.yaml; do
+            echo "Walnut will check file ${file}"
           done
 
   # workflow-check:

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -38,11 +38,11 @@ jobs:
         working-directory: ./Control
         run: |
           for file in ./../ControlWorkflows/tasks/*.yaml; do
-            echo "Walnut will check file ${file}"
+            walnut check -f task ${file}
           done
       - name: Run Walnut checks for WORKFLOWS
         working-directory: ./Control
         run: |
             for file in ./../ControlWorkflows/workflows/*.yaml; do
-              echo "Walnut will check file ${file}"
+              walnut check -f workflow ${file}
             done

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -7,25 +7,21 @@ on:
       - '.github/workflows/template.yml'
   push:
     branches:
-      - 'feature/OCTRL-317-add-gh-action-walnut'
       - 'master'
 
 jobs:
   tasks-check:
     name: Check Tasks Templates through Walnut
-    # runs-on: ${{ matrix.os }}
-    runs-on: macOS-latest
-    # strategy:
-    #   matrix:
-    #     os: [macOS-latest, ubuntu-18.04]
-    #     go: [ '1.14.7', '1.15.0' ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
         with:
             path: ControlWorkflows
       - uses: actions/setup-go@v2
         with:
-          # go-version: ${{matrix.go}}
           go-version: '1.15.0'
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -32,30 +32,17 @@ jobs:
           repository: AliceO2Group/Control
           ref: 'master'
           path: Control
-      # - run: make vendor
-      # - run: make
-      - name: Run Walnut checks for tasks
+      - run: make vendor
+      - run: make
+      - name: Run Walnut checks for TASKS
         working-directory: ./Control
         run: |
           for file in ./../ControlWorkflows/tasks/*.yaml; do
             echo "Walnut will check file ${file}"
           done
-
-  # workflow-check:
-  #       name: Check Workflow Templates through Walnut
-  #       runs-on: ${{ matrix.os }}
-  #       strategy:
-  #         matrix:
-  #           os: [macOS-latest, ubuntu-18.04]
-  #           go: [ '1.14.7', '1.15.0' ]
-  #       steps:
-  #         - uses: actions/checkout@v2
-  #         - uses: actions/setup-go@v2
-  #           with:
-  #             go-version: ${{matrix.go}}
-  #         - uses: actions/checkout@v2
-  #           with: 
-  #             repository: AliceO2Group/Control
-  #             ref: 'master'
-  #         - run: (cd Control; echo "In Control now")
-  #         - run: (cd ControlWorkflows; echo "In ControlWorfklows now")
+      - name: Run Walnut checks for WORKFLOWS
+        working-directory: ./Control
+        run: |
+            for file in ./../ControlWorkflows/workflows/*.yaml; do
+              echo "Walnut will check file ${file}"
+            done

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -15,10 +15,11 @@ jobs:
     name: Check Tasks Templates through Walnut
     # runs-on: ${{ matrix.os }}
     runs-on: macOS-latest
-    # strategy:
-    #   matrix:
+    strategy:
+      matrix:
     #     os: [macOS-latest, ubuntu-18.04]
     #     go: [ '1.14.7', '1.15.0' ]
+          checkDirectories: ['tasks', 'workflows']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,8 +33,15 @@ jobs:
           repository: AliceO2Group/Control
           ref: 'master'
           path: Control
-      - run: (cd Control; echo "In Control now")
-      - run: (cd ControlWorkflows; echo "In ControlWorfklows now")
+      # - run: make vendor
+      # - run: make
+      - name: Run Walnut checks for tasks
+        working-directory: ./Control
+        run: |
+          for file in ./../ControlWorkflows/{{ matrix.tasks }}/*.yml; do
+            echo "Walnut will check file ${file} in folder ${{ matrix.tasks }}"
+          done
+
   # workflow-check:
   #       name: Check Workflow Templates through Walnut
   #       runs-on: ${{ matrix.os }}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -38,11 +38,13 @@ jobs:
         working-directory: ./Control
         run: |
           for file in ./../ControlWorkflows/tasks/*.yaml; do
+            echo "Checking file ${file}"
             ./bin/walnut check -f task ${file}
           done
       - name: Run Walnut checks for WORKFLOWS
         working-directory: ./Control
         run: |
             for file in ./../ControlWorkflows/workflows/*.yaml; do
+              echo "Checking file ${file}"
               ./bin/walnut check -f workflow ${file}
             done

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -10,8 +10,8 @@ on:
       - 'master'
 
 jobs:
-  tasks-check:
-    name: Check Tasks Templates through Walnut
+  walnut-check:
+    name: Check Task and Workflow Templates through Walnut
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -32,8 +32,8 @@ jobs:
           repository: AliceO2Group/Control
           ref: 'master'
           path: Control
-      - run: make vendor
-      - run: make
+      - run: (cd Control; make vendor)
+      - run: (cd Control; make)
       - name: Run Walnut checks for TASKS
         working-directory: ./Control
         run: |

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -38,11 +38,11 @@ jobs:
         working-directory: ./Control
         run: |
           for file in ./../ControlWorkflows/tasks/*.yaml; do
-            walnut check -f task ${file}
+            ./bin/walnut check -f task ${file}
           done
       - name: Run Walnut checks for WORKFLOWS
         working-directory: ./Control
         run: |
             for file in ./../ControlWorkflows/workflows/*.yaml; do
-              walnut check -f workflow ${file}
+              ./bin/walnut check -f workflow ${file}
             done

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
             path: ControlWorkflows
+            ref: 'flp-suite-v0.10.0'
       - uses: actions/setup-go@v2
         with:
           # go-version: ${{matrix.go}}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -15,8 +15,8 @@ jobs:
     name: Check Tasks Templates through Walnut
     # runs-on: ${{ matrix.os }}
     runs-on: macOS-latest
-    strategy:
-      matrix:
+    # strategy:
+    #   matrix:
     #     os: [macOS-latest, ubuntu-18.04]
     #     go: [ '1.14.7', '1.15.0' ]
     steps:

--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ All variables are optional.
 | `odc_hostname` | The hostname where ODC (EPN control) is running (only if `odc_enabled` is `true`) | `localhost` |
 | `odc_port` | The port where ODC (EPN control) is listening (only if `odc_enabled` is `true`) | `50051` |
 | `odc_topology_path` | Path to a DDS topology file, local to `odc_hostname` (only if `odc_enabled` is `true`) | `/etc/o2.d/odc/ex-dds-topology-infinite.xml` |
+
+# Notes on the CI Pipeline
+
+In order to ensure a successful addition or modification of a template (task/workflow), every pull request will run a `walnut check` command against each file individually. 
+
+If there is an error during the execution of `walnut check` command, the pipeline will stop and print out the exit code and the output provided by the command.
+
+These checks are ran automatically against:
+*  os: `macOS-latest`, go-version: `1.15.0` 
+*  os: `ubuntu-18.04`, go-version: `1.15.0` 
+
+Source code can be found [here.](.github/workflows/template.yml)

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ If there is an error during the execution of `walnut check` command, the pipelin
 These checks are ran automatically against:
 *  os: `macOS-latest`, go-version: `1.15.0` 
 *  os: `ubuntu-18.04`, go-version: `1.15.0` 
+*  `walnut` version: [Control/master](https://github.com/AliceO2Group/Control/tree/master/)
 
 Source code can be found [here.](.github/workflows/template.yml)


### PR DESCRIPTION
GH Action which will be running a `walnut check` on all files present in directories `tasks` & `workflows`. Checks are ran against the `to be merged` version of the branch. 

If there are any changes to the branch `master` without a PR, than the checks will be triggered as well.  

If a walnut check will fail, than the pipeline will stop, print the failure message and exit code. 
E.g https://github.com/AliceO2Group/ControlWorkflows/runs/1067418002?check_suite_focus=true

Checks are ran on 2 setups:
* macOS-latest with go v1.15.0
*  ubuntu-18.04 with go v1.15.0
