### PR TITLE
Allow to choose the data origin (detector) in minimal DPL wf

### DIFF
--- a/tasks/minimal-dpl-dpl-output-proxy.yaml
+++ b/tasks/minimal-dpl-dpl-output-proxy.yaml
@@ -1,6 +1,7 @@
 name: minimal-dpl-dpl-output-proxy
 defaults:
   user: flp
+  detector: TST
 control:
   mode: "fairmq"
 wants:
@@ -16,7 +17,7 @@ command:
   shell: true
   value: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 Control-OCCPlugin &&
-    cat {{dpl_config}} | o2-dpl-output-proxy
+    o2-dpl-raw-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-dpl-output-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-dpl-output-proxy
   user: "{{ user }}"
   arguments:
     - "-b"
@@ -25,7 +26,7 @@ command:
     - "--id"
     - "dpl-output-proxy"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--channel-config"
     - "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"
     - "--proxy-name"

--- a/tasks/minimal-dpl-internal-dpl-clock.yaml
+++ b/tasks/minimal-dpl-internal-dpl-clock.yaml
@@ -1,6 +1,7 @@
 name: minimal-dpl-internal-dpl-clock
 defaults:
   user: flp
+  detector: TST
 control:
   mode: "fairmq"
 wants:
@@ -16,12 +17,12 @@ command:
   shell: true
   value: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 Control-OCCPlugin &&
-    cat {{dpl_config}} | o2-dpl-raw-proxy
+    o2-dpl-raw-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-dpl-output-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-dpl-raw-proxy
   user: "{{ user }}"
   arguments:
     - "-b"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--monitoring-backend"
     - "{{ monitoring_qc_url }}"
     - "--id"

--- a/tasks/minimal-dpl-readout-proxy.yaml
+++ b/tasks/minimal-dpl-readout-proxy.yaml
@@ -1,6 +1,7 @@
 name: minimal-dpl-readout-proxy
 defaults:
   user: flp
+  detector: TST
 control:
   mode: "fairmq"
 wants:
@@ -16,7 +17,7 @@ command:
   shell: true
   value: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load O2 Control-OCCPlugin &&
-    cat {{dpl_config}} | o2-dpl-raw-proxy
+    o2-dpl-raw-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-dpl-output-proxy -b --session default --dataspec "x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0" --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-dpl-raw-proxy
   user: "{{ user }}"
   arguments:
     - "-b"
@@ -25,7 +26,7 @@ command:
     - "--id"
     - "readout-proxy"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--log-color"
     - "false"
     - "--readers"

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -13,7 +13,7 @@ defaults:
   monitoring_qc_url: "no-op://"
   monitoring_dd_url: "no-op://"
   monitoring_readout_url: "no-op://"
-  detector: TEST
+  detector: TST
 roles:
   - name: host-{{ it }}
     for:


### PR DESCRIPTION
@teo 
This is needed to allow for any other data origin than TST (i.e. a real detector). I am not happy about these pipe trains before the real command, but I see no other sane way to make it work with what we have. DPL doesn't allow us to put a wildcard for data origin (e.g. "x:***/RAWDATA"), so we have to choose a specific value in i/o proxies.

Another way to achieve this would be to create DPL dump files for each possible detector and choose between them. Not very fun neither.

To use any real detector, one should set the "detector" variable accordingly.