### PR TITLE
Workflow generation scripts

### DIFF
--- a/scripts/datasampling-02.sh
+++ b/scripts/datasampling-02.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME='datasampling-02'
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/datasampling-02.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-datasampling-standalone --config $QC_GEN_CONFIG_PATH --pipeline "Dispatcher:2" | o2-dpl-output-proxy -b --session default --dataspec 'x:TST/SMPRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/etc/datasampling-02.json
+++ b/scripts/etc/datasampling-02.json
@@ -1,0 +1,22 @@
+{
+  "dataSamplingPolicies": [
+    {
+      "id": "sampling1",
+      "active": "true",
+      "machines": [
+        "localhost"
+      ],
+      "query": "x:TST/RAWDATA",
+      "outputs": "y:TST/SMPRAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    } 
+  ]
+}
+

--- a/scripts/etc/hmpid-raw-qc.json
+++ b/scripts/etc/hmpid-raw-qc.json
@@ -1,0 +1,57 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "piotr-ostack:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+	    "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "piotr-ostack:8500"
+      },
+      "conditionDB": {
+        "url": "piotr-ostack:8083"
+      }
+    },
+    "tasks": {
+      "HMPIDRawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::hmpid::HmpidTask",
+        "moduleName": "QcHMPID",
+        "detectorName": "HMP",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "readout"
+        },
+        "location": "remote"
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "readout",
+      "active": "true",
+      "machines": [],
+      "query" : "readout:HMP/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/hmpid-raw-qcmn.json
+++ b/scripts/etc/hmpid-raw-qcmn.json
@@ -1,0 +1,63 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "piotr-ostack:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+	    "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "piotr-ostack:8500"
+      },
+      "conditionDB": {
+        "url": "piotr-ostack:8083"
+      }
+    },
+    "tasks": {
+      "HMPIDRawTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::hmpid::HmpidTask",
+        "moduleName": "QcHMPID",
+        "detectorName": "HMP",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "readout"
+        },
+        "location": "local",
+        "localMachines": [
+           "alio2-cr1-flp160",
+           "alio2-cr1-flp161"
+        ],
+        "remotePort":"43215",
+        "remoteMachine":"anything"
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "readout",
+      "active": "true",
+      "machines": [],
+      "query" : "readout:HMP/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/its-qc-fhr-fee.json
+++ b/scripts/etc/its-qc-fhr-fee.json
@@ -1,0 +1,124 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "piotr-ostack2:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "piotr-ostack2:8500"
+      },
+      "conditionDB": {
+        "url": "piotr-ostack2:8083"
+      }
+    },
+    "tasks": {
+      "FHRTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFhrTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "31",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "RAWDATA"
+        },
+        "location": "remote",
+        "taskParameters": {
+          "Layer": "2",
+          "decoderThreads": "8",
+          "runNumberPath": "/data/shifts/runs/ibb2a/.run_counter",
+          "geomPath": "/tmp/qc_tmp/o2sim"
+        }
+      },
+      "ITSFEE": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFeeTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "feedata"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "FHRCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFhrCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "FHRTask",
+            "MOs": [
+              "General/ErrorPlots"
+            ]
+          }
+        ]
+      },
+      "ITSFeeCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFeeCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ITSFEE",
+            "MOs": [
+              "LaneStatus/laneStatusFlagFAULT"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "RAWDATA",
+      "active": "true",
+      "machines": [],
+      "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "feedata",
+      "active": "true",
+      "machines": [],
+      "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/its-qcmn-fhr-fee.json
+++ b/scripts/etc/its-qcmn-fhr-fee.json
@@ -1,0 +1,156 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "piotr-ostack2:8083",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "piotr-ostack2:8500"
+      },
+      "conditionDB": {
+        "url": "piotr-ostack2:8083"
+      }
+    },
+    "tasks": {
+      "FHRTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFhrTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "31",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "RAWDATA"
+        },
+        "location": "local",
+        "taskParameters": {
+          "Layer": "2",
+          "decoderThreads": "8",
+          "runNumberPath": "/data/shifts/runs/ibb2a/.run_counter",
+          "geomPath": "/tmp/qc_tmp/o2sim"
+        },
+        "localMachines": [
+          "alio2-cr1-flp187",
+          "alio2-cr1-flp188",
+          "alio2-cr1-flp189",
+          "alio2-cr1-flp190",
+          "alio2-cr1-flp191",
+          "alio2-cr1-flp192",
+          "alio2-cr1-flp193",
+          "alio2-cr1-flp194",
+          "alio2-cr1-flp195",
+          "alio2-cr1-flp196",
+          "alio2-cr1-flp197",
+          "alio2-cr1-flp198"
+        ],
+        "remotePort": "33012",
+        "remoteMachine": "alio2-cr1-qme04"
+      },
+      "ITSFEE": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFeeTask",
+        "moduleName": "QcITS",
+        "detectorName": "ITS",
+        "cycleDurationSeconds": "30",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "feedata"
+        },
+        "location": "local",
+        "localMachines": [
+          "alio2-cr1-flp187",
+          "alio2-cr1-flp188",
+          "alio2-cr1-flp189",
+          "alio2-cr1-flp190",
+          "alio2-cr1-flp191",
+          "alio2-cr1-flp192",
+          "alio2-cr1-flp193",
+          "alio2-cr1-flp194",
+          "alio2-cr1-flp195",
+          "alio2-cr1-flp196",
+          "alio2-cr1-flp197",
+          "alio2-cr1-flp198"
+       ],
+       "remotePort": "44154",
+       "remoteMachine": "alio2-cr1-qme04"
+      }
+    },
+    "checks": {
+      "FHRCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFhrCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "FHRTask",
+            "MOs": [
+              "General/ErrorPlots"
+            ]
+          }
+        ]
+      },
+      "ITSFeeCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::its::ITSFeeCheck",
+        "moduleName": "QcITS",
+        "policy": "OnAny",
+        "detectorName": "ITS",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "ITSFEE",
+            "MOs": [
+              "LaneStatus/laneStatusFlagFAULT"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "RAWDATA",
+      "active": "true",
+      "machines": [],
+      "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "feedata",
+      "active": "true",
+      "machines": [],
+      "query": "filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1441"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/mft-raw-digits-qc.json
+++ b/scripts/etc/mft-raw-digits-qc.json
@@ -1,0 +1,118 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "BasicReadoutHeaderQcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::BasicReadoutHeaderQcTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "RAWDATA"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "remote"
+      },
+      "BasicDigitQcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::BasicDigitQcTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "mft-digits"
+        },
+        "taskParameters": {
+          "FLP": "0",
+          "TaskLevel": "0"
+        },
+        "location": "remote"
+      }
+    },
+    "checks": {
+      "BasicReadoutHeaderQcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::BasicReadoutHeaderQcCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnEachSeparately",
+        "dataSource": [{
+          "type": "Task",
+          "name": "BasicReadoutHeaderQcTask",
+          "MOs": ["mMFT_SummaryLaneStatus_H"]
+        }]
+      },
+      "BasicDigitQcCheck": {
+        "active": "false",
+        "dataSource": [{
+          "type": "Task",
+          "name": "BasicDigitQcTask"
+        }],
+        "className": "o2::quality_control_modules::mft::BasicDigitQcCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnEachSeparately"
+      } 
+    }    
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "RAWDATA",
+      "active": "true",
+      "machines": [],
+      "query": "filter:MFT/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    },
+    {
+      "id": "mft-digits",
+      "active": "true",
+      "machines": [],
+      "query": "randomdigit:MFT/DIGITS/0",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/mft-raw-qcmn.json
+++ b/scripts/etc/mft-raw-qcmn.json
@@ -1,0 +1,84 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "BasicReadoutHeaderQcTask": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::BasicReadoutHeaderQcTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "cycleDurationSeconds": "60",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "RAWDATA"
+        },
+        "taskParameters": {
+          "myOwnKey": "myOwnValue"
+        },
+        "location": "local",
+        "localMachines": [
+          "alio2-cr1-flp182",
+          "alio2-cr1-flp183",
+          "alio2-cr1-flp184",
+          "alio2-cr1-flp185",
+          "alio2-cr1-flp186"
+        ],
+        "remotePort": "62323",
+        "remoteMachine": "anything"
+      }
+    },
+    "checks": {
+      "BasicReadoutHeaderQcCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::mft::BasicReadoutHeaderQcCheck",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "policy": "OnEachSeparately",
+        "dataSource": [{
+          "type": "Task",
+          "name": "BasicReadoutHeaderQcTask",
+          "MOs": ["mMFT_SummaryLaneStatus_H"]
+        }]
+      }
+    }    
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "RAWDATA",
+      "active": "true",
+      "machines": [],
+      "query": "filter:MFT/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/phos-compressor-raw-qc.json
+++ b/scripts/etc/phos-compressor-raw-qc.json
@@ -1,0 +1,61 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "ccdb-test.cern.ch:8080",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": "http://localhost:8500"
+            },
+            "conditionDB": {
+                "url": "ccdb-test.cern.ch:8080"
+            }
+        },
+       "tasks": {
+        "QcTask": {
+          "active": "true",
+          "className": "o2::quality_control_modules::phos::RawQcTask",
+          "moduleName": "QcPHOS",
+          "detectorName": "PHS",
+          "cycleDurationSeconds": "10",
+          "maxNumberCycles": "-1",
+          "dataSource": {
+            "type": "dataSamplingPolicy",
+            "name": "phos-rawerr"
+          },
+          "taskParameters": {
+            "pedestal": "on"    
+          },
+          "location": "remote"
+        }
+      }
+    },
+    "dataSamplingPolicies": [
+      {
+        "id": "phos-rawerr",
+        "active": "true",
+        "machines": [],
+        "query_comment" : "query is in the format of binding1:origin1/description1/subSpec1[;binding2:...]",
+        "query": "rawerr:PHS/RAWHWERRORS/0;cells:PHS/CELLS/0;cellstr:PHS/CELLTRIGREC/0",
+        "samplingConditions": [
+          {
+            "condition": "random",
+            "fraction": "1.",
+            "seed": "1234"
+          }
+        ],
+        "blocking": "false"
+      }
+  ]
+}

--- a/scripts/etc/phos-compressor-raw-qcmn.json
+++ b/scripts/etc/phos-compressor-raw-qcmn.json
@@ -1,0 +1,67 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "ccdb-test.cern.ch:8080",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "infologger:///debug?qc"
+            },
+            "consul": {
+                "url": "http://localhost:8500"
+            },
+            "conditionDB": {
+                "url": "ccdb-test.cern.ch:8080"
+            }
+        },
+       "tasks": {
+        "QcTask": {
+          "active": "true",
+          "className": "o2::quality_control_modules::phos::RawQcTask",
+          "moduleName": "QcPHOS",
+          "detectorName": "PHS",
+          "cycleDurationSeconds": "10",
+          "maxNumberCycles": "-1",
+          "dataSource": {
+            "type": "dataSamplingPolicy",
+            "name": "phos-rawerr"
+          },
+          "taskParameters": {
+            "pedestal": "on"    
+          },
+          "location": "local",
+          "localMachines": [
+            "alio2-cr1-flp164",
+            "alio2-cr1-flp165"
+          ],
+          "remoteMachine": "anything",
+          "remotePort": "43244"
+        }
+      }
+    },
+    "dataSamplingPolicies": [
+      {
+        "id": "phos-rawerr",
+        "active": "true",
+        "machines": [],
+        "query_comment" : "query is in the format of binding1:origin1/description1/subSpec1[;binding2:...]",
+        "query": "rawerr:PHS/RAWHWERRORS/0;cells:PHS/CELLS/0;cellstr:PHS/CELLTRIGREC/0",
+        "samplingConditions": [
+          {
+            "condition": "random",
+            "fraction": "1.",
+            "seed": "1234"
+          }
+        ],
+        "blocking": "false"
+      }
+  ]
+}

--- a/scripts/etc/qc-daq.json
+++ b/scripts/etc/qc-daq.json
@@ -1,0 +1,75 @@
+{
+    "qc": {
+        "config": {
+            "database": {
+                "implementation": "CCDB",
+                "host": "piotr-ostack:8083",
+                "username": "not_applicable",
+                "password": "not_applicable",
+                "name": "not_applicable"
+            },
+            "Activity": {
+                "number": "42",
+                "type": "2"
+            },
+            "monitoring": {
+                "url": "influxdb-unix:///tmp/telegraf.sock"
+            },
+            "consul": {
+                "url": "piotr-ostack:8500"
+            },
+            "conditionDB": {
+                "url": "piotr-ostack:8083"
+            }
+        },
+        "tasks": {
+            "dataDistribution": {
+                "active": "true",
+                "className": "o2::quality_control_modules::daq::DaqTask",
+                "moduleName": "QcDaq",
+                "detectorName": "DAQ",
+                "cycleDurationSeconds": "10",
+                "maxNumberCycles": "-1",
+                "dataSource": {
+                    "type": "dataSamplingPolicy",
+                    "name": "datadistribution"
+                },
+                "location": "remote"
+            }
+        },
+        "checks": {
+            "QcCheck": {
+                "active": "true",
+                "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+                "moduleName": "QcSkeleton",
+                "policy": "OnAny",
+                "detectorName" : "DAQ",
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "dataDistribution",
+                        "MOs": [
+                            "payloadSizeInputs"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "dataSamplingPolicies": [
+        {
+            "id": "datadistribution",
+            "active": "true",
+            "machines": [],
+            "query": "readout:TST/RAWDATA",
+            "samplingConditions": [
+                {
+                    "condition": "random",
+                    "fraction": "1.0",
+                    "seed": "1248"
+                }
+            ],
+            "blocking": "false"
+        }
+    ]
+}

--- a/scripts/etc/qcmn-daq.json
+++ b/scripts/etc/qcmn-daq.json
@@ -1,0 +1,82 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "MultiNodeLocal": {
+        "active": "true",
+        "className": "o2::quality_control_modules::daq::DaqTask",
+        "moduleName": "QcDaq",
+        "detectorName": "DAQ",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "rnd-many"
+        },
+        "taskParameters": {},
+        "location": "local",
+        "localMachines": [
+          "alio2-cr1-mvs01",
+          "alio2-cr1-mvs02"
+        ],
+        "remoteMachine": "alio2-cr1-qme08",
+        "remotePort": "30132",
+        "mergingMode": "delta"
+      }
+    },
+    "checks": {
+      "MultiNodeLocalCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::skeleton::SkeletonCheck",
+        "moduleName": "QcSkeleton",
+        "policy": "OnAny",
+        "detectorName": "TST",
+        "dataSource": [{
+          "type": "Task",
+          "name": "MultiNodeLocal",
+          "MOs": ["payloadSizeInputs"]
+        }]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "rnd-many",
+      "active": "true",
+      "machines": [
+        "alio2-cr1-mvs01",
+        "alio2-cr1-mvs02"
+      ],
+      "query": "readout:TST/RAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "0.1",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/etc/tof-qcmn-compressor.json
+++ b/scripts/etc/tof-qcmn-compressor.json
@@ -1,0 +1,105 @@
+{
+  "qc": {
+    "config": {
+      "database": {
+        "implementation": "CCDB",
+        "host": "ccdb-test.cern.ch:8080",
+        "username": "not_applicable",
+        "password": "not_applicable",
+        "name": "not_applicable"
+      },
+      "Activity": {
+        "number": "42",
+        "type": "2"
+      },
+      "monitoring": {
+        "url": "infologger:///debug?qc"
+      },
+      "consul": {
+        "url": "http://consul-test.cern.ch:8500"
+      },
+      "conditionDB": {
+        "url": "ccdb-test.cern.ch:8080"
+      }
+    },
+    "tasks": {
+      "TaskRaw": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::TaskRaw",
+        "moduleName": "QcTOF",
+        "detectorName": "TOF",
+        "cycleDurationSeconds": "10",
+        "maxNumberCycles": "-1",
+        "dataSource_comment": "The other type of dataSource is \"direct\", see basic-no-sampling.json.",
+        "dataSource": {
+          "type": "dataSamplingPolicy",
+          "name": "raw-local"
+        },
+        "taskParameters": {
+          "nothing": "rien"
+        },
+        "location": "local",
+        "localMachines": [
+          "alio2-cr1-flp178",
+          "alio2-cr1-flp179"
+        ],
+        "remoteMachine": "anything",
+        "remotePort": "30132",
+        "mergingMode": "delta"
+      }
+    },
+    "checks": {
+      "CheckDiagnostics": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckDiagnostics",
+        "moduleName": "QcTOF",
+        "detectorName": "TOF",
+        "policy": "OnAny",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskRaw",
+            "MOs": [
+              "RDHCounterCrate0"
+            ]
+          }
+        ]
+      },
+      "CheckCompressedData": {
+        "active": "true",
+        "className": "o2::quality_control_modules::tof::CheckCompressedData",
+        "moduleName": "QcTOF",
+        "detectorName": "TOF",
+        "policy": "OnAny",
+        "checkParameters": {
+          "DiagnosticThresholdPerSlot": "10"
+        },
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "TaskRaw",
+            "MOs": [
+              "hDiagnostic"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "dataSamplingPolicies": [
+    {
+      "id": "raw-local",
+      "active": "true",
+      "machines": [],
+      "query": "dataframe:TOF/CRAWDATA",
+      "samplingConditions": [
+        {
+          "condition": "random",
+          "fraction": "1.0",
+          "seed": "1234"
+        }
+      ],
+      "blocking": "false"
+    }
+  ]
+}

--- a/scripts/generate-all-dpl-workflows.sh
+++ b/scripts/generate-all-dpl-workflows.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#set -x;
+set -e;
+set -u;
+
+# This will run all the scripts for regenerating the WFTs&TTs.
+# Please note that:
+# - you have to enter the O2 environment to run these scripts
+# - the scripts use GNU sed. Not expected to work on Mac
+# - when regenerating the templates, use the closest sw versions to the target versions
+# - do not name workflows so one name includes other. e.g. 'its-qc-one' and 'its-qc'.
+#   otherwise the sed commands for 'its-qc's TTs might affect 'its-qc-one' as well.
+
+
+# ./datasampling-02.sh # this is a test workflow, no need for it in production
+./hmpid-raw-qcmn.sh
+./hmpid-raw-qc.sh
+./its-qc-fhr-fee.sh
+./its-qcmn-fhr-fee.sh
+./mft-decoder.sh
+./mft-digits-qc.sh
+# ./mft-raw-digits-qc.sh # disabled until the MFT decoder is fixed and we optimize the workflow
+./mft-raw-qcmn.sh
+./mft-raw-qc.sh
+./mid-raw-parser.sh
+./minimal-dpl.sh
+./phos-compressor-raw-qc.sh
+./phos-compressor-raw-qcmn.sh
+./phos-compressor.sh
+./qc-daq.sh
+./qcmn-daq.sh
+./tof-compressor.sh
+./tof-qcmn-compressor.sh
+
+

--- a/scripts/hmpid-raw-qc.sh
+++ b/scripts/hmpid-raw-qc.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=hmpid-raw-qc
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/hmpid-raw-qc.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/hmpid_raw_qc-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:HMP/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'x:HMP/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/hmpid-raw-qcmn.sh
+++ b/scripts/hmpid-raw-qcmn.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=hmpid-raw-qcmn-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/hmpid-raw-qcmn.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/hmpid-raw-qcmn'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:HMP/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'x:HMP/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} --local --host alio2-cr1-flp160 -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+
+# QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
+WF_NAME=hmpid-raw-qcmn-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/its-qc-fhr-fee.sh
+++ b/scripts/its-qc-fhr-fee.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#set -x;
+set -e;
+set -u;
+
+WF_NAME=its-qc-fhr-fee
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qc-fhr-fee.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/its-qcmn-fhr-fee.sh
+++ b/scripts/its-qcmn-fhr-fee.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=its-qcmn-fhr-fee-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qcmn-fhr-fee.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'filter:ITS/RAWDATA;G:FLP/DISTSUBTIMEFRAME' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config $QC_GEN_CONFIG_PATH --local --host alio2-cr1-flp187 -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
+WF_NAME=its-qcmn-fhr-fee-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/mft-decoder.sh
+++ b/scripts/mft-decoder.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mft-decoder
+
+cd ../ 
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-itsmft-stf-decoder-workflow -b --runmft --digits --no-clusters --no-cluster-patterns --session default | o2-dpl-output-proxy -b --session default --dataspec 'x:MFT/DIGITS;y:MFT/DIGITSROF;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' --o2-control $WF_NAME
+

--- a/scripts/mft-digits-qc.sh
+++ b/scripts/mft-digits-qc.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mft-digits-qc
+QC_GEN_CONFIG_PATH='json://'${QUALITYCONTROL_ROOT}'/etc/mft-digit-qc-task-FLP-0-TaskLevel-0.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-itsmft-stf-decoder-workflow -b --runmft --digits --no-clusters --no-cluster-patterns | o2-dpl-output-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/mft-raw-digits-qc.sh
+++ b/scripts/mft-raw-digits-qc.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mft-raw-digits-qc
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-digits-qc.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-itsmft-stf-decoder-workflow -b --runmft --digits --no-clusters --no-cluster-patterns | o2-dpl-output-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/mft-raw-qc.sh
+++ b/scripts/mft-raw-qc.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mft-raw-qc
+QC_GEN_CONFIG_PATH='json://'${QUALITYCONTROL_ROOT}'/etc/mft-basic-readout-header-qc-task.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/mft-raw-qcmn.sh
+++ b/scripts/mft-raw-qcmn.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mft-raw-qcmn-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-qcmn.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-raw-qcmn'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'x:MFT/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' | o2-qc --config ${QC_GEN_CONFIG_PATH} --local --host alio2-cr1-flp182 -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+
+# QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
+WF_NAME=mft-raw-qcmn-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/mid-raw-parser.sh
+++ b/scripts/mid-raw-parser.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=mid-raw-parser
+
+cd ..
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'A:MID/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --channel-config name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=5 | o2-dpl-raw-parser -b --session default --input-spec A:MID/RAWDATA --log-level 0 | o2-dpl-output-proxy -b --session default --dataspec 'A:MID/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' --o2-control $WF_NAME
+

--- a/scripts/minimal-dpl.sh
+++ b/scripts/minimal-dpl.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=minimal-dpl
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:ZYX/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-dpl-output-proxy -b --session default --dataspec 'x:ZYX/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' --o2-control $WF_NAME
+
+sed -i "s/ZYX/{{ detector }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i /defaults:/\ a\\\ \\\ "detector: TST" workflows/${WF_NAME}.yaml
+
+

--- a/scripts/phos-compressor-raw-qc.sh
+++ b/scripts/phos-compressor-raw-qc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=phos-compressor-raw-qc
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qc.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:PHS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-phos-reco-workflow -b --input-type raw --output-type cells --session default --disable-root-output --pedestal off --keepHGLG off | o2-dpl-output-proxy -b --session default --dataspec 'A:PHS/CELLS/0;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-qc -b --config ${QC_GEN_CONFIG_PATH} --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+sed -i /defaults:/\ a\\\ \\\ "phos_keep_hglg: off" workflows/${WF_NAME}.yaml
+sed -i /defaults:/\ a\\\ \\\ "phos_pedestal: off" workflows/${WF_NAME}.yaml
+
+sed -i '/--pedestal/{n;s/.*/    - "{{ phos_pedestal }}"/}' tasks/${WF_NAME}-*
+sed -i '/--keepHGLG/{n;s/.*/    - "{{ phos_keep_hglg }}"/}' tasks/${WF_NAME}-*
+

--- a/scripts/phos-compressor-raw-qcmn.sh
+++ b/scripts/phos-compressor-raw-qcmn.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=phos-compressor-raw-qcmn-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qcmn.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-compressor-raw-qcmn'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+o2-dpl-raw-proxy -b --session default --dataspec 'x:PHS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-phos-reco-workflow -b --input-type raw --output-type cells --session default --disable-root-output --pedestal off --keepHGLG off | o2-dpl-output-proxy -b --session default --dataspec 'A:PHS/CELLS/0;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-qc -b --config ${QC_GEN_CONFIG_PATH} --local --host alio2-cr1-flp164 --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+sed -i /defaults:/\ a\\\ \\\ "phos_keep_hglg: off" workflows/${WF_NAME}.yaml
+sed -i /defaults:/\ a\\\ \\\ "phos_pedestal: off" workflows/${WF_NAME}.yaml
+
+sed -i '/--pedestal/{n;s/.*/    - "{{ phos_pedestal }}"/}' tasks/${WF_NAME}-*
+sed -i '/--keepHGLG/{n;s/.*/    - "{{ phos_keep_hglg }}"/}' tasks/${WF_NAME}-*
+
+
+# QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
+WF_NAME=phos-compressor-raw-qcmn-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/phos-compressor.sh
+++ b/scripts/phos-compressor.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=phos-compressor
+
+cd ..
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:PHS/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-phos-reco-workflow -b --input-type raw --output-type cells --session default --disable-root-output --pedestal off --keepHGLG off --pipeline 'PHOSRawToCellConverterSpec:1' | o2-dpl-output-proxy -b --session default --dataspec 'A:PHS/CELLS/0;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' --o2-control $WF_NAME
+
+sed -i /defaults:/\ a\\\ \\\ "phos_keep_hglg: off" workflows/${WF_NAME}.yaml
+sed -i /defaults:/\ a\\\ \\\ "phos_pedestal: off" workflows/${WF_NAME}.yaml
+
+sed -i '/--pedestal/{n;s/.*/    - "{{ phos_pedestal }}"/}' tasks/${WF_NAME}-*
+sed -i '/--keepHGLG/{n;s/.*/    - "{{ phos_keep_hglg }}"/}' tasks/${WF_NAME}-*

--- a/scripts/qc-daq.sh
+++ b/scripts/qc-daq.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=qc-daq
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/qc-daq.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/stfb_to_daqtask-{{ it }}'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-qc -b --config ${QC_GEN_CONFIG_PATH} | o2-dpl-output-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# replace TST with a parameter
+sed -i "s/TST/{{ detector }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# add a default value for detector
+sed -i /defaults:/\ a\\\ \\\ "detector: TST" workflows/${WF_NAME}.yaml
+
+
+

--- a/scripts/qcmn-daq.sh
+++ b/scripts/qcmn-daq.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=qcmn-daq-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/qcmn-daq.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+# DPL commands to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-qc --config $QC_GEN_CONFIG_PATH --local --host alio2-cr1-mvs01 -b | o2-dpl-output-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"' --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+
+WF_NAME=qcmn-daq-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+

--- a/scripts/tof-compressor.sh
+++ b/scripts/tof-compressor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=tof-compressor
+
+cd ..
+
+# DPL command to generate the AliECS dump
+o2-dpl-raw-proxy -b --session default --dataspec 'x0:TOF/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-tof-compressor -b --session default --pipeline tof-compressor-0:6 --tof-compressor-rdh-version 6 --tof-compressor-config x:TOF/RAWDATA | o2-dpl-output-proxy -b --session default --dataspec 'A:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' --o2-control $WF_NAME
+

--- a/scripts/tof-qcmn-compressor.sh
+++ b/scripts/tof-qcmn-compressor.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+WF_NAME=tof-qcmn-compressor-local
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/tof-qcmn-compressor.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/tof-qcmn-compressor'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ../
+
+# DPL command to generate the AliECS dump
+
+o2-dpl-raw-proxy -b --session default --dataspec 'x0:TOF/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-tof-compressor -b --session default --pipeline tof-compressor-0:6 --tof-compressor-rdh-version 6 --tof-compressor-config x:TOF/RAWDATA | o2-dpl-output-proxy -b --session default --dataspec 'A:TOF/CRAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-qc -b --config $QC_GEN_CONFIG_PATH --local --host alio2-cr1-flp178 --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+
+# QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
+WF_NAME=tof-qcmn-compressor-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+


### PR DESCRIPTION
Hopefully they won't be needed once we have JIT translation, but for now, they will allow us to regenerate all the WFTs&TTs we support with `generate-all-dpl-workflows.sh`.

There are QC config files stored in scripts/etc, so the QC workflows can be correctly generated. It is not ideal to keep them here, but again, I hope this is temporary.