### PR TITLE
Add missing --resources-monitoring option

### DIFF
--- a/tasks/hmpid-raw-qc-Dispatcher.yaml
+++ b/tasks/hmpid-raw-qc-Dispatcher.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'Dispatcher'"
     - "--shm-monitor"

--- a/tasks/hmpid-raw-qc-QC-CHECK-RUNNER-sink-QC_HMPIDRawTask-mo_0.yaml
+++ b/tasks/hmpid-raw-qc-QC-CHECK-RUNNER-sink-QC_HMPIDRawTask-mo_0.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-sink-QC_HMPIDRawTask-mo_0'"
     - "--shm-monitor"

--- a/tasks/hmpid-raw-qc-QC-TASK-RUNNER-HMPIDRawTask.yaml
+++ b/tasks/hmpid-raw-qc-QC-TASK-RUNNER-HMPIDRawTask.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-HMPIDRawTask'"
     - "--shm-monitor"

--- a/tasks/hmpid-raw-qc-dpl-output-proxy.yaml
+++ b/tasks/hmpid-raw-qc-dpl-output-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'dpl-output-proxy'"
     - "--shm-monitor"

--- a/tasks/hmpid-raw-qc-internal-dpl-clock.yaml
+++ b/tasks/hmpid-raw-qc-internal-dpl-clock.yaml
@@ -47,6 +47,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/hmpid-raw-qc-readout-proxy.yaml
+++ b/tasks/hmpid-raw-qc-readout-proxy.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'readout-proxy'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-Dispatcher.yaml
+++ b/tasks/its-qc-fhr-fee-Dispatcher.yaml
@@ -42,6 +42,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'Dispatcher'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-QC-CHECK-RUNNER-FHRCheck.yaml
+++ b/tasks/its-qc-fhr-fee-QC-CHECK-RUNNER-FHRCheck.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-FHRCheck'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-QC-CHECK-RUNNER-ITSFeeCheck.yaml
+++ b/tasks/its-qc-fhr-fee-QC-CHECK-RUNNER-ITSFeeCheck.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-ITSFeeCheck'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-QC-TASK-RUNNER-FHRTask.yaml
+++ b/tasks/its-qc-fhr-fee-QC-TASK-RUNNER-FHRTask.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-FHRTask'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-QC-TASK-RUNNER-ITSFEE.yaml
+++ b/tasks/its-qc-fhr-fee-QC-TASK-RUNNER-ITSFEE.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-ITSFEE'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-dpl-output-proxy.yaml
+++ b/tasks/its-qc-fhr-fee-dpl-output-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'dpl-output-proxy'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-internal-dpl-clock.yaml
+++ b/tasks/its-qc-fhr-fee-internal-dpl-clock.yaml
@@ -52,6 +52,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/its-qc-fhr-fee-internal-dpl-injected-dummy-sink.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"

--- a/tasks/its-qc-fhr-fee-readout-proxy.yaml
+++ b/tasks/its-qc-fhr-fee-readout-proxy.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'readout-proxy'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-Dispatcher.yaml
+++ b/tasks/mft-digits-qc-Dispatcher.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'Dispatcher'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-QC-CHECK-RUNNER-sink-QC_BasicDigitQcT-mo_0.yaml
+++ b/tasks/mft-digits-qc-QC-CHECK-RUNNER-sink-QC_BasicDigitQcT-mo_0.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-sink-QC_BasicDigitQcT-mo_0'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-QC-TASK-RUNNER-BasicDigitQcTask.yaml
+++ b/tasks/mft-digits-qc-QC-TASK-RUNNER-BasicDigitQcTask.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-BasicDigitQcTask'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-dpl-output-proxy.yaml
+++ b/tasks/mft-digits-qc-dpl-output-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'dpl-output-proxy'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-internal-dpl-clock.yaml
+++ b/tasks/mft-digits-qc-internal-dpl-clock.yaml
@@ -47,6 +47,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/mft-digits-qc-internal-dpl-injected-dummy-sink.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-mft-stf-decoder.yaml
+++ b/tasks/mft-digits-qc-mft-stf-decoder.yaml
@@ -42,6 +42,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'mft-stf-decoder'"
     - "--shm-monitor"

--- a/tasks/mft-digits-qc-readout-proxy.yaml
+++ b/tasks/mft-digits-qc-readout-proxy.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'readout-proxy'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-Dispatcher.yaml
+++ b/tasks/mft-raw-qc-Dispatcher.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'Dispatcher'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-QC-CHECK-RUNNER-BasicReadoutHeaderQcCheck.yaml
+++ b/tasks/mft-raw-qc-QC-CHECK-RUNNER-BasicReadoutHeaderQcCheck.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-BasicReadoutHeaderQcCheck'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-QC-TASK-RUNNER-BasicReadoutHeaderQcTask.yaml
+++ b/tasks/mft-raw-qc-QC-TASK-RUNNER-BasicReadoutHeaderQcTask.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-BasicReadoutHeaderQcTask'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-dpl-output-proxy.yaml
+++ b/tasks/mft-raw-qc-dpl-output-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'dpl-output-proxy'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-internal-dpl-clock.yaml
+++ b/tasks/mft-raw-qc-internal-dpl-clock.yaml
@@ -47,6 +47,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/mft-raw-qc-internal-dpl-injected-dummy-sink.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"

--- a/tasks/mft-raw-qc-readout-proxy.yaml
+++ b/tasks/mft-raw-qc-readout-proxy.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'readout-proxy'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-Dispatcher.yaml
+++ b/tasks/phos-compressor-raw-qc-Dispatcher.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'Dispatcher'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-PHOSRawToCellConverterSpec.yaml
+++ b/tasks/phos-compressor-raw-qc-PHOSRawToCellConverterSpec.yaml
@@ -47,6 +47,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'PHOSRawToCellConverterSpec'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-QC-CHECK-RUNNER-sink-QC_QcTask-mo_0.yaml
+++ b/tasks/phos-compressor-raw-qc-QC-CHECK-RUNNER-sink-QC_QcTask-mo_0.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-sink-QC_QcTask-mo_0'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-QC-TASK-RUNNER-QcTask.yaml
+++ b/tasks/phos-compressor-raw-qc-QC-TASK-RUNNER-QcTask.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-TASK-RUNNER-QcTask'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-dpl-output-proxy.yaml
+++ b/tasks/phos-compressor-raw-qc-dpl-output-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'dpl-output-proxy'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-internal-dpl-clock.yaml
+++ b/tasks/phos-compressor-raw-qc-internal-dpl-clock.yaml
@@ -47,6 +47,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/phos-compressor-raw-qc-internal-dpl-injected-dummy-sink.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"

--- a/tasks/phos-compressor-raw-qc-readout-proxy.yaml
+++ b/tasks/phos-compressor-raw-qc-readout-proxy.yaml
@@ -42,6 +42,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'readout-proxy'"
     - "--shm-monitor"

--- a/tasks/qcmn-daq-remote-MERGER-MultiNodeLocal1l-0.yaml
+++ b/tasks/qcmn-daq-remote-MERGER-MultiNodeLocal1l-0.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'MERGER-MultiNodeLocal1l-0'"
     - "--shm-monitor"

--- a/tasks/qcmn-daq-remote-MultiNodeLocal-proxy.yaml
+++ b/tasks/qcmn-daq-remote-MultiNodeLocal-proxy.yaml
@@ -43,6 +43,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'MultiNodeLocal-proxy'"
     - "--shm-monitor"

--- a/tasks/qcmn-daq-remote-QC-CHECK-RUNNER-MultiNodeLocalCheck.yaml
+++ b/tasks/qcmn-daq-remote-QC-CHECK-RUNNER-MultiNodeLocalCheck.yaml
@@ -37,6 +37,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'QC-CHECK-RUNNER-MultiNodeLocalCheck'"
     - "--shm-monitor"

--- a/tasks/qcmn-daq-remote-internal-dpl-clock.yaml
+++ b/tasks/qcmn-daq-remote-internal-dpl-clock.yaml
@@ -42,6 +42,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-clock'"
     - "--shm-monitor"

--- a/tasks/qcmn-daq-remote-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/qcmn-daq-remote-internal-dpl-injected-dummy-sink.yaml
@@ -32,6 +32,8 @@ command:
     - "'{{ shm_segment_size }}'"
     - "--shm-throw-bad-alloc"
     - "'{{ shm_throw_bad_alloc }}'"
+    - "--resources-monitoring"
+    - "'{{ resources_monitoring }}'"
     - "--id"
     - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"

--- a/workflows/hmpid-raw-qc.yaml
+++ b/workflows/hmpid-raw-qc.yaml
@@ -10,6 +10,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:

--- a/workflows/its-qc-fhr-fee.yaml
+++ b/workflows/its-qc-fhr-fee.yaml
@@ -10,6 +10,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:

--- a/workflows/mft-digits-qc.yaml
+++ b/workflows/mft-digits-qc.yaml
@@ -10,6 +10,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:

--- a/workflows/mft-raw-qc.yaml
+++ b/workflows/mft-raw-qc.yaml
@@ -10,6 +10,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:

--- a/workflows/phos-compressor-raw-qc.yaml
+++ b/workflows/phos-compressor-raw-qc.yaml
@@ -12,6 +12,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:

--- a/workflows/qcmn-daq-remote.yaml
+++ b/workflows/qcmn-daq-remote.yaml
@@ -10,6 +10,7 @@ defaults:
   shm_segment_size: 10000000000
   shm_throw_bad_alloc: false
   session_id: default
+  resources_monitoring: 15
 roles:
   - name: "internal-dpl-clock"
     connect:


### PR DESCRIPTION
There was a bunch of workflows generated without `--resources-monitoring` option enabled (needed to enable CPU/memory monitoring in DPL). This brings it to the missing places.