### PR TITLE
Async PartitionInitialize for ddsched

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -216,6 +216,7 @@ roles:
         call:
           func: ddsched.PartitionInitialize()
           trigger: before_CONFIGURE
+          await: after_CONFIGURE
           timeout: 5s
           critical: true
       - name: terminate


### PR DESCRIPTION
This will unblock the timeout issue described on the `OCTRL-446`. The hooks will start concurrently