### PR TITLE
Fix MCH config file

### DIFF
--- a/scripts/etc/mch-qcmn-digits.json
+++ b/scripts/etc/mch-qcmn-digits.json
@@ -11,6 +11,15 @@
       "Activity": {
         "number": "42",
         "type": "2"
+      },
+      "monitoring": {
+        "url": "influxdb-unix:///tmp/telegraf.sock"
+      },
+      "consul": {
+        "url": "null:8500"
+      },
+      "conditionDB": {
+        "url": "null:8083"
       }
     },
     "tasks": {


### PR DESCRIPTION
Some missing config values were preventing the QC to dump the workflow templates.