### PR TITLE
[EMCAL-718,EMCAL-725]Adding remote workflow for running raw QC on the…

### DIFF
--- a/scripts/emc-qcmn-epnall.sh
+++ b/scripts/emc-qcmn-epnall.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+source helpers.sh
+
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/emc-qcmn-epnall.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-epnall'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+WF_NAME=emc-qcmn-epnall-remote
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+add_fmq_shmmonitor_role workflows/${WF_NAME}.yaml
+add_qc_remote_machine_attribute workflows/${WF_NAME}.yaml alio2-cr1-qc02

--- a/scripts/etc/emc-qcmn-epnall.json
+++ b/scripts/etc/emc-qcmn-epnall.json
@@ -1,0 +1,216 @@
+{
+	"qc": {
+	    "config": {
+		"database": {
+		    "implementation": "CCDB",
+		    "host": "alio2-cr1-hv-qcdb1.cern.ch:8083",
+		    "username": "not_applicable",
+		    "password": "not_applicable",
+		    "name": "not_applicable"
+		},
+		"Activity": {
+		    "number": "42",
+		    "type": "2"
+		},
+		"monitoring": {
+		    "url": "infologger:///debug?qc"
+		},
+		"consul": {
+		    "url": "http://consul-test.cern.ch:8500"
+		},
+		"conditionDB": {
+		    "url": "ccdb-test.cern.ch:8080"
+		}
+	    },
+	    "tasks": {
+		"RawTask": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::RawTask",
+		    "moduleName": "QcEMCAL",
+		    "detectorName": "EMC",
+		    "cycleDurationSeconds": "60",
+		    "maxNumberCycles": "-1",
+		    "dataSource": {
+		      "type": "dataSamplingPolicy",
+		      "name": "emcrawdata"
+		    },
+		    "location": "local",
+		    "localMachines": [
+			"epn"
+		    ],
+		    "remoteMachine": "alio2-cr1-qc02.cern.ch",
+		    "remotePort": "47701",
+		    "mergingMode": "delta",
+		    "localControl": "odc"
+		},
+		"DigitsTask": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitsQcTask",
+		    "moduleName": "QcEMCAL",
+		    "detectorName": "EMC",
+		    "cycleDurationSeconds": "60",
+		    "maxNumberCycles": "-1",
+		    "dataSource": {
+			"type": "dataSamplingPolicy",
+			"name": "emccells"
+		    },
+		    "taskParameters": {
+			"nothing": "rien"
+		    },
+		    "location": "local",
+		    "localMachines": [
+			"epn"
+		    ],
+		    "remoteMachine": "alio2-cr1-qc02.cern.ch",
+		    "remotePort": "47702",
+		    "mergingMode": "delta",
+		    "localControl": "odc"
+		}
+	    },
+	    "checks": {
+		"RawCheck": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::RawCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "dataSource": [{
+			  "type": "Task",
+			  "name": "RawTask",
+			  "MOs": "all"
+		    }]
+		},
+		"checkAmplHighG": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitAmplitudeHG_CAL",
+				"digitAmplitudeHG_PHYS"
+			    ]
+			}
+		    ]
+		},
+		"checkAmplLowG": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitAmplitudeLG_CAL",
+				"digitAmplitudeLG_PHYS"
+			    ]
+			}
+		    ]
+		},
+		"checkDigitTimeHighG": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitTimeHG_CAL",
+				"digitTimeHG_PHYS"
+			    ]
+			}
+		    ]
+		},
+		"checkDigitTimeLowG": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitTimeLG_CAL",
+				"digitTimeLG_PHYS"
+			    ]
+			}
+		    ]
+		},
+		"checkAmplEMCAL": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitAmplitudeEMCAL_CAL",
+				"digitAmplitudeEMCAL_PHYS"
+			    ]
+			}
+		    ]
+		},
+		"checkAmplDCAL": {
+		    "active": "true",
+		    "className": "o2::quality_control_modules::emcal::DigitCheck",
+		    "moduleName": "QcEMCAL",
+		    "policy": "OnAny",
+		    "detectorName": "EMC",
+		    "dataSource": [
+			{
+			    "type": "Task",
+			    "name": "DigitsTask",
+			    "MOs": [
+				"digitAmplitudeDCAL_CAL",
+				"digitAmplitudeDCAL_PHYS"
+			    ]
+			}
+		    ]
+		}
+	    }
+	},
+	"dataSamplingPolicies": [
+	    {
+		"id": "emcrawdata",
+		"active": "true",
+		"machines": ["epn"],
+		"query": "readout:EMC/RAWDATA",
+		"samplingConditions": [
+		    {
+			"condition": "random",
+			"fraction": "0.01",
+			"seed": "1248"
+		    }
+		],
+		"blocking": "false"
+		},
+	  {
+		"id": "emccells",
+		"active": "true",
+		"machines": ["epn"],
+		"query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
+		"samplingConditions": [
+		    {
+			"condition": "random",
+			"fraction": "0.1",
+			"seed": "1248"
+		    }
+		],
+		"blocking": "false"
+	    }
+	]
+    }

--- a/tasks/emc-qcmn-epnall-remote-DigitsTask-proxy.yaml
+++ b/tasks/emc-qcmn-epnall-remote-DigitsTask-proxy.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-MERGER-DigitsTask1l-0
+name: emc-qcmn-epnall-remote-DigitsTask-proxy
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,11 +11,17 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
+  - name: from_DigitsTask-proxy_to_MERGER-DigitsTask1l-0
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
+  - name: DigitsTask-proxy
+    type: pull
+    transport: zeromq
+    addressing: tcp
+    rateLogging: "{{ fmq_rate_logging }}"
+    target: "tcp://*:47702"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -41,7 +47,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsTask1l-0'"
+    - "'DigitsTask-proxy'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -105,5 +111,13 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--period-timer-publish"
-    - "'60000000'"
+    - "--end-value-enumeration"
+    - "-1"
+    - "--orbit-multiplier-enumeration"
+    - "'0'"
+    - "--orbit-offset-enumeration"
+    - "'0'"
+    - "--start-value-enumeration"
+    - "'0'"
+    - "--step-value-enumeration"
+    - "'1'"

--- a/tasks/emc-qcmn-epnall-remote-MERGER-DigitsTask1l-0.yaml
+++ b/tasks/emc-qcmn-epnall-remote-MERGER-DigitsTask1l-0.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-flpepn-remote-DigitsQC-proxy
+name: emc-qcmn-epnall-remote-MERGER-DigitsTask1l-0
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,17 +11,11 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_DigitsQC-proxy_to_MERGER-DigitsQC1l-0
+  - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
-  - name: DigitsQC-proxy
-    type: pull
-    transport: zeromq
-    addressing: tcp
-    rateLogging: "{{ fmq_rate_logging }}"
-    target: "tcp://*:47702"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -47,7 +41,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'DigitsQC-proxy'"
+    - "'MERGER-DigitsTask1l-0'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -111,13 +105,5 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--end-value-enumeration"
-    - "-1"
-    - "--orbit-multiplier-enumeration"
-    - "'0'"
-    - "--orbit-offset-enumeration"
-    - "'0'"
-    - "--start-value-enumeration"
-    - "'0'"
-    - "--step-value-enumeration"
-    - "'1'"
+    - "--period-timer-publish"
+    - "'60000000'"

--- a/tasks/emc-qcmn-epnall-remote-MERGER-RawTask1l-0.yaml
+++ b/tasks/emc-qcmn-epnall-remote-MERGER-RawTask1l-0.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-MERGER-DigitsTask1l-0
+name: emc-qcmn-epnall-remote-MERGER-RawTask1l-0
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,7 +11,7 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
+  - name: from_MERGER-RawTask1l-0_to_QC-CHECK-RUNNER-RawCheck
     type: push
     transport: shmem
     addressing: ipc
@@ -41,7 +41,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsTask1l-0'"
+    - "'MERGER-RawTask1l-0'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"

--- a/tasks/emc-qcmn-epnall-remote-QC-CHECK-RUNNER-4280.yaml
+++ b/tasks/emc-qcmn-epnall-remote-QC-CHECK-RUNNER-4280.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-DigitsQC-proxy
+name: emc-qcmn-epnall-remote-QC-CHECK-RUNNER-4280
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,17 +11,11 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_DigitsQC-proxy_to_MERGER-DigitsQC1l-0
+  - name: from_QC-CHECK-RUNNER-4280_to_internal-dpl-injected-dummy-sink
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
-  - name: DigitsQC-proxy
-    type: pull
-    transport: zeromq
-    addressing: tcp
-    rateLogging: "{{ fmq_rate_logging }}"
-    target: "tcp://*:47702"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -47,7 +41,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'DigitsQC-proxy'"
+    - "'QC-CHECK-RUNNER-4280'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -111,13 +105,3 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--end-value-enumeration"
-    - "-1"
-    - "--orbit-multiplier-enumeration"
-    - "'0'"
-    - "--orbit-offset-enumeration"
-    - "'0'"
-    - "--start-value-enumeration"
-    - "'0'"
-    - "--step-value-enumeration"
-    - "'1'"

--- a/tasks/emc-qcmn-epnall-remote-QC-CHECK-RUNNER-RawCheck.yaml
+++ b/tasks/emc-qcmn-epnall-remote-QC-CHECK-RUNNER-RawCheck.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-MERGER-DigitsTask1l-0
+name: emc-qcmn-epnall-remote-QC-CHECK-RUNNER-RawCheck
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,7 +11,7 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
+  - name: from_QC-CHECK-RUNNER-RawCheck_to_internal-dpl-injected-dummy-sink
     type: push
     transport: shmem
     addressing: ipc
@@ -41,7 +41,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsTask1l-0'"
+    - "'QC-CHECK-RUNNER-RawCheck'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -105,5 +105,3 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--period-timer-publish"
-    - "'60000000'"

--- a/tasks/emc-qcmn-epnall-remote-RawTask-proxy.yaml
+++ b/tasks/emc-qcmn-epnall-remote-RawTask-proxy.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-MERGER-DigitsQC1l-0
+name: emc-qcmn-epnall-remote-RawTask-proxy
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,11 +11,17 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsQC1l-0_to_QC-CHECK-RUNNER-4280
+  - name: from_RawTask-proxy_to_MERGER-RawTask1l-0
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
+  - name: RawTask-proxy
+    type: pull
+    transport: zeromq
+    addressing: tcp
+    rateLogging: "{{ fmq_rate_logging }}"
+    target: "tcp://*:47701"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -41,7 +47,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsQC1l-0'"
+    - "'RawTask-proxy'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -105,5 +111,13 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--period-timer-publish"
-    - "'10000000'"
+    - "--end-value-enumeration"
+    - "-1"
+    - "--orbit-multiplier-enumeration"
+    - "'0'"
+    - "--orbit-offset-enumeration"
+    - "'0'"
+    - "--start-value-enumeration"
+    - "'0'"
+    - "--step-value-enumeration"
+    - "'1'"

--- a/tasks/emc-qcmn-epnall-remote-internal-dpl-clock.yaml
+++ b/tasks/emc-qcmn-epnall-remote-internal-dpl-clock.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-epn-remote-MERGER-DigitsTask1l-0
+name: emc-qcmn-epnall-remote-internal-dpl-clock
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,7 +11,22 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
+  - name: from_internal-dpl-clock_to_DigitsTask-proxy
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+  - name: from_internal-dpl-clock_to_RawTask-proxy
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+  - name: from_internal-dpl-clock_to_MERGER-DigitsTask1l-0
+    type: push
+    transport: shmem
+    addressing: ipc
+    rateLogging: "{{ fmq_rate_logging }}"
+  - name: from_internal-dpl-clock_to_MERGER-RawTask1l-0
     type: push
     transport: shmem
     addressing: ipc
@@ -41,7 +56,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsTask1l-0'"
+    - "'internal-dpl-clock'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -105,5 +120,3 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--period-timer-publish"
-    - "'60000000'"

--- a/tasks/emc-qcmn-epnall-remote-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/emc-qcmn-epnall-remote-internal-dpl-injected-dummy-sink.yaml
@@ -1,4 +1,4 @@
-name: emc-qcmn-flpepn-remote-MERGER-DigitsQC1l-0
+name: emc-qcmn-epnall-remote-internal-dpl-injected-dummy-sink
 defaults:
   log_task_output: none
   _module_cmdline: >-
@@ -11,11 +11,6 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_MERGER-DigitsQC1l-0_to_QC-CHECK-RUNNER-4280
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -41,7 +36,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'MERGER-DigitsQC1l-0'"
+    - "'internal-dpl-injected-dummy-sink'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -105,5 +100,3 @@ command:
     - "'all'"
     - "--workflow-suffix"
     - "''"
-    - "--period-timer-publish"
-    - "'10000000'"

--- a/workflows/emc-qcmn-epnall-remote.yaml
+++ b/workflows/emc-qcmn-epnall-remote.yaml
@@ -1,0 +1,121 @@
+name: emc-qcmn-epnall-remote
+vars:
+  dpl_command: >-
+    o2-qc --config {{ qc_config_uri }} --remote -b
+defaults:
+  qc_remote_machine: "alio2-cr1-qc02"
+  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-epnall"
+  monitoring_dpl_url: "no-op://"
+  user: "flp"
+  fmq_rate_logging: 0
+  shm_segment_size: 10000000000
+  shm_throw_bad_alloc: false
+  session_id: default
+  resources_monitoring: 15
+constraints:
+  - attribute: machine_id
+    value: "{{ qc_remote_machine }}"
+roles:
+  - name: "internal-dpl-clock"
+    connect:
+    task:
+      load: emc-qcmn-epnall-remote-internal-dpl-clock
+  - name: "DigitsTask-proxy"
+    connect:
+    - name: from_internal-dpl-clock_to_DigitsTask-proxy
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_DigitsTask-proxy"
+      rateLogging: "{{ fmq_rate_logging }}"
+    bind:
+    - name: DigitsTask-proxy
+      type: pull
+      transport: zeromq
+      addressing: tcp
+      rateLogging: "{{ fmq_rate_logging }}"
+      target: "tcp://*:47702"
+    task:
+      load: emc-qcmn-epnall-remote-DigitsTask-proxy
+  - name: "RawTask-proxy"
+    connect:
+    - name: from_internal-dpl-clock_to_RawTask-proxy
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_RawTask-proxy"
+      rateLogging: "{{ fmq_rate_logging }}"
+    bind:
+    - name: RawTask-proxy
+      type: pull
+      transport: zeromq
+      addressing: tcp
+      rateLogging: "{{ fmq_rate_logging }}"
+      target: "tcp://*:47701"
+    task:
+      load: emc-qcmn-epnall-remote-RawTask-proxy
+  - name: "MERGER-DigitsTask1l-0"
+    connect:
+    - name: from_internal-dpl-clock_to_MERGER-DigitsTask1l-0
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_MERGER-DigitsTask1l-0"
+      rateLogging: "{{ fmq_rate_logging }}"
+    - name: from_DigitsTask-proxy_to_MERGER-DigitsTask1l-0
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.DigitsTask-proxy:from_DigitsTask-proxy_to_MERGER-DigitsTask1l-0"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: emc-qcmn-epnall-remote-MERGER-DigitsTask1l-0
+  - name: "MERGER-RawTask1l-0"
+    connect:
+    - name: from_internal-dpl-clock_to_MERGER-RawTask1l-0
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_MERGER-RawTask1l-0"
+      rateLogging: "{{ fmq_rate_logging }}"
+    - name: from_RawTask-proxy_to_MERGER-RawTask1l-0
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.RawTask-proxy:from_RawTask-proxy_to_MERGER-RawTask1l-0"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: emc-qcmn-epnall-remote-MERGER-RawTask1l-0
+  - name: "QC-CHECK-RUNNER-4280"
+    connect:
+    - name: from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.MERGER-DigitsTask1l-0:from_MERGER-DigitsTask1l-0_to_QC-CHECK-RUNNER-4280"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: emc-qcmn-epnall-remote-QC-CHECK-RUNNER-4280
+  - name: "QC-CHECK-RUNNER-RawCheck"
+    connect:
+    - name: from_MERGER-RawTask1l-0_to_QC-CHECK-RUNNER-RawCheck
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.MERGER-RawTask1l-0:from_MERGER-RawTask1l-0_to_QC-CHECK-RUNNER-RawCheck"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: emc-qcmn-epnall-remote-QC-CHECK-RUNNER-RawCheck
+  - name: "internal-dpl-injected-dummy-sink"
+    connect:
+    - name: from_QC-CHECK-RUNNER-4280_to_internal-dpl-injected-dummy-sink
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.QC-CHECK-RUNNER-4280:from_QC-CHECK-RUNNER-4280_to_internal-dpl-injected-dummy-sink"
+      rateLogging: "{{ fmq_rate_logging }}"
+    - name: from_QC-CHECK-RUNNER-RawCheck_to_internal-dpl-injected-dummy-sink
+      type: pull
+      transport: shmem
+      target: "{{ Parent().Path }}.QC-CHECK-RUNNER-RawCheck:from_QC-CHECK-RUNNER-RawCheck_to_internal-dpl-injected-dummy-sink"
+      rateLogging: "{{ fmq_rate_logging }}"
+    task:
+      load: emc-qcmn-epnall-remote-internal-dpl-injected-dummy-sink
+  - name: fairmq-shmmonitor
+    enabled: "{{fmq_cleanup_enabled == 'true'}}"
+    task:
+      load: "fairmq-shmmonitor"
+      trigger: DESTROY
+      timeout: 10s
+      critical: false

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -99,6 +99,7 @@ defaults:
       - none
       - emc-qcmn-flp-remote
       - emc-qcmn-epn-remote
+      - emc-qcmn-epnall-remote
       - emc-qcmn-flpepn-remote
       - qcmn-daq-remote
   emc_dcs_sor_parameters: !public


### PR DESCRIPTION
… EPN

In case both raw and digits QC are running on the EPN
a separate remote workflow is needed ot fix different
ports for the raw and digits proxy as the raw proxy
is no longer handled by ecs but by odc.