### PR TITLE
Increase DCS SOR timeout to 140s

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1078,7 +1078,7 @@ roles:
         call:
           func: dcs.StartOfRun()
           trigger: enter_RUNNING
-          timeout: 120s
+          timeout: 140s
           critical: true
       - name: eor
         call:


### PR DESCRIPTION
At the request of TPC, for LASER runs. 
To be merged after the pilot beam.