### PR TITLE
[OGUI-1018] Add GH check for GUIs variables

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -15,7 +15,7 @@ defaults:
     value: "true"
     type: bool
     label: "Data Distribution (FLP)"
-    description: "Enable/disable Data Distr2ibution components running on FLPs (StfBuilder and StfSender)"
+    description: "Enable/disable Data Distribution components running on FLPs (StfBuilder and StfSender)"
     widget: checkBox
     panel: Basic_Configuration
     index: -100


### PR DESCRIPTION
PR which: 
* Adds a GH Action which will automatically check if any of the fixed variables used on the GUI side will be affected.
* If it identifies any of the `keys` (full list of variables used by the GUI [here](https://github.com/AliceO2Group/WebUi/tree/dev/Control#list-of-fixed-variables-used-by-aliecs-gui-for-user-logic) ) the action will fail and an error will be displayed plus the lines which are failing;
* The GH Action uses `git diff --word-diff` and looks only for changes in variable keys from the list
* The GH Action will be triggered only for changes in directories `workflows` or `tasks`

This check is needed so that no functionality is broken on the GUI side with changes done by mistake.
Examples:
* of failing job due to `epn_enabled` variable being renamed to `epn_e2nabled` : https://github.com/AliceO2Group/ControlWorkflows/runs/4046641264?check_suite_focus=true#step:6:21 
* of successful job with changes to other variables: https://github.com/AliceO2Group/ControlWorkflows/runs/4046917517?check_suite_focus=true#step:6:20