### PR TITLE
Fix the class name in TPC QC post calib

### DIFF
--- a/scripts/etc/tpc-qc-post-calib.json
+++ b/scripts/etc/tpc-qc-post-calib.json
@@ -364,7 +364,7 @@
     "checks": {
       "PadCalibrationCheck2D": {
         "active": "true",
-        "className": "o2::quality_control_modules::tpc::PadCalibrationCheck2D",
+        "className": "o2::quality_control_modules::tpc::PadCalibrationCheck",
         "moduleName": "QcTPC",
         "policy": "OnEachSeparately",
         "detectorName": "TPC",


### PR DESCRIPTION
It does not have any influence on the template, but the wrong value in consul was breaking the workflow. Fixing it also here for consistency.