### PR TITLE
[EMCAL-524] Fix renamed binding

### DIFF
--- a/scripts/etc/emc-qcmn-epn.json
+++ b/scripts/etc/emc-qcmn-epn.json
@@ -75,7 +75,7 @@
             "id": "emccells",
             "active": "true",
             "machines": ["epn"],
-            "query": "emcal-digits:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0",
+            "query": "emcal-cells:EMC/CELLS/0;emcal-triggerecords:EMC/CELLSTRGR/0",
             "samplingConditions": [
                 {
                     "condition": "random",

--- a/scripts/etc/emc-qcmn-epnall.json
+++ b/scripts/etc/emc-qcmn-epnall.json
@@ -174,7 +174,7 @@
 			"id": "emccells",
 			"active": "true",
 			"machines": ["epn"],
-			"query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
+			"query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
 			"samplingConditions": [
 			    {
 					"condition": "random",

--- a/scripts/etc/emc-qcmn-flpepn.json
+++ b/scripts/etc/emc-qcmn-flpepn.json
@@ -173,7 +173,7 @@
             "id": "emccells",
             "active": "true",
             "machines": ["epn"],
-            "query": "emcal-digits:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
+            "query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
             "samplingConditions": [
                 {
                     "condition": "random",


### PR DESCRIPTION
For consistency the binding emcal-digits
was also renamed to emcal-cells