### PR TITLE
MFT: Update of QC Task/Check naming in the mft-full-qcmn json.

### DIFF
--- a/scripts/etc/mft-full-digits-sampling.json
+++ b/scripts/etc/mft-full-digits-sampling.json
@@ -9,7 +9,7 @@
       "samplingConditions": [
         {
           "condition": "random",
-          "fraction": "0.05",
+          "fraction": "0.01",
           "seed": "0"
         }
       ]

--- a/scripts/etc/mft-full-qcmn.json
+++ b/scripts/etc/mft-full-qcmn.json
@@ -3,7 +3,7 @@
     "config": {
       "database": {
         "implementation": "CCDB",
-        "host": "ccdb-test.cern.ch:8080",
+        "host": "ali-qcdb.cern.ch:8083",
         "username": "not_applicable",
         "password": "not_applicable",
         "name": "not_applicable"
@@ -13,17 +13,17 @@
         "type": "2"
       },
       "monitoring": {
-        "url": "infologger:///debug?qc"
+        "url": "influxdb-unix:///tmp/telegraf.sock"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": "http://ali-consul.cern.ch:8500"
       },
       "conditionDB": {
-        "url": "ccdb-test.cern.ch:8080"
+        "url": "http://localhost:8084"
       }
     },
     "tasks": {
-      "QcMFTReadoutTask": {
+      "MFTReadoutTask": {
         "active": "true",
         "className": "o2::quality_control_modules::mft::QcMFTReadoutTask",
         "moduleName": "QcMFT",
@@ -39,7 +39,7 @@
         "remoteMachine": "any",
         "remotePort": "47798"
       },
-      "QcMFTDigitTask": {
+      "MFTDigitTask": {
         "active": "true",
         "className": "o2::quality_control_modules::mft::QcMFTDigitTask",
         "moduleName": "QcMFT",
@@ -59,7 +59,7 @@
         "remoteMachine": "any",
         "remotePort": "47799"
       },
-      "QcMFTClusterTask": {
+      "MFTClusterTask": {
         "active": "true",
         "className": "o2::quality_control_modules::mft::QcMFTClusterTask",
         "moduleName": "QcMFT",
@@ -80,7 +80,7 @@
       }
     },
     "checks": {
-      "QcMFTReadoutCheck": {
+      "MFTReadoutCheck": {
         "active": "true",
         "className": "o2::quality_control_modules::mft::QcMFTReadoutCheck",
         "moduleName": "QcMFT",
@@ -88,11 +88,11 @@
         "policy": "OnEachSeparately",
         "dataSource": [{
           "type": "Task",
-          "name": "QcMFTReadoutTask",
-          "MOs": ["mMFTSummaryLaneStatus"]
+          "name": "MFTReadoutTask",
+            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
         }]
       },
-      "QcMFTDigitCheck": {
+      "MFTDigitCheck": {
         "active": "true",
         "className": "o2::quality_control_modules::mft::QcMFTDigitCheck",
         "moduleName": "QcMFT",
@@ -100,20 +100,17 @@
         "policy": "OnEachSeparately",
         "dataSource": [{
           "type": "Task",
-          "name": "QcMFTDigitTask"
+          "name": "MFTDigitTask",
+            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         }]
       },
-      "QcMFTClusterCheck": {
+      "MFTClusterCheck": {
         "active": "true",
-        "dataSource": [
-          {
+        "dataSource": [{
             "type": "Task",
-            "name": "QcMFTClusterTask",
-            "MOs": [
-              "mMFTClusterSensorIndex"
-            ]
-          }
-        ],
+            "name": "MFTClusterTask",
+            "MOs" : ["mClusterOccupancy"]
+        }],
         "className": "o2::quality_control_modules::mft::QcMFTClusterCheck",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
@@ -131,7 +128,7 @@
         {
           "condition": "random",
           "fraction": "0.01",
-          "seed": "1234"
+          "seed": "0"
         }
       ],
       "blocking": "false"


### PR DESCRIPTION
Update of QC Task/Check naming in the mft-full-qcmn json to comply with the 16 character maximum for name length. 
Minor changes in the MOs for the checkers. Also update of the CCDB path (just for consistency as it does not have real effect). 

In the digit sampling json adjusting the sampling ratio to be consistent with the one in the Consul. 