### PR TITLE
Revert "make DCS calls non-critical"

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1558,19 +1558,19 @@ roles:
           func: dcs.StartOfRun()
           trigger: before_START_ACTIVITY
           timeout: "{{ dcs_sor_timeout }}"
-          critical: false
+          critical: true
       - name: eor
         call:
           func: dcs.EndOfRun()
           trigger: after_STOP_ACTIVITY
           timeout: "{{ dcs_eor_timeout }}"
-          critical: false
+          critical: true
       - name: cleanup
         call:
           func: dcs.Cleanup()
           trigger: DESTROY
           timeout: "{{ dcs_cleanup_timeout }}"
-          critical: false
+          critical: true
   - name: dd-scheduler
     enabled: "{{ddsched_enabled == 'true'}}"
     roles:


### PR DESCRIPTION
This reverts commit 2f393616e05c3eed5764890eef0aa8e057237d2f.

To be deployed at P2 next Monday with the upgrade of FLP Suite v0.51.0.
Should be then cherry-picked into master.