### PR TITLE
daq-qcmn: detector variable instead of TST

### DIFF
--- a/scripts/qcmn-daq.sh
+++ b/scripts/qcmn-daq.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# set -x;
+set -x;
 set -e;
 set -u;
 
@@ -28,6 +28,11 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 
 # sed -i "s/alio2-cr1-mvs01/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
 
+# replace TST with a parameter
+sed -i "s/:TST\//:{{ detector }}\//g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# add a default value for detector
+sed -i /defaults:/\ a\\\ \\\ "detector: TST" workflows/${WF_NAME}.yaml
 
 WF_NAME=qcmn-daq-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
@@ -43,8 +48,14 @@ sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG
 ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
 sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
 
+# replace TST with a parameter
+#sed -i "s/TST/{{ detector }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+
+# add a default value for detector
+#sed -i /defaults:/\ a\\\ \\\ "detector: TST" workflows/${WF_NAME}.yaml
+
 add_fmq_shmmonitor_role workflows/${WF_NAME}.yaml
-add_qc_remote_machine_attribute workflows/${WF_NAME}.yaml alio2-cr1-qme08 
+add_qc_remote_machine_attribute workflows/${WF_NAME}.yaml alio2-cr1-qme08
 
 
 

--- a/tasks/qcmn-daq-local-dpl-output-proxy.yaml
+++ b/tasks/qcmn-daq-local-dpl-output-proxy.yaml
@@ -70,7 +70,7 @@ command:
     - "--clone"
     - "''"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--default-port"
     - "'4200'"
     - "--default-transport"

--- a/tasks/qcmn-daq-local-internal-dpl-clock.yaml
+++ b/tasks/qcmn-daq-local-internal-dpl-clock.yaml
@@ -85,7 +85,7 @@ command:
     - "--clone"
     - "''"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"

--- a/tasks/qcmn-daq-local-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/qcmn-daq-local-internal-dpl-injected-dummy-sink.yaml
@@ -57,7 +57,7 @@ command:
     - "--clone"
     - "''"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--fairmq-ipc-prefix"
     - "'/tmp'"
     - "--fairmq-rate-logging"

--- a/tasks/qcmn-daq-local-readout-proxy.yaml
+++ b/tasks/qcmn-daq-local-readout-proxy.yaml
@@ -78,7 +78,7 @@ command:
     - "--clone"
     - "''"
     - "--dataspec"
-    - "'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
+    - "'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0'"
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"

--- a/workflows/qcmn-daq-local.yaml
+++ b/workflows/qcmn-daq-local.yaml
@@ -1,8 +1,9 @@
 name: qcmn-daq-local
 vars:
   dpl_command: >-
-    o2-dpl-raw-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-qc --config {{ qc_config_uri }} --local --host alio2-cr1-mvs01 -b | o2-dpl-output-proxy -b --session default --dataspec 'x:TST/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"'
+    o2-dpl-raw-proxy -b --session default --dataspec 'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-qc --config {{ qc_config_uri }} --local --host alio2-cr1-mvs01 -b | o2-dpl-output-proxy -b --session default --dataspec 'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"'
 defaults:
+  detector: TST
   qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq"
   monitoring_dpl_url: "no-op://"
   user: "flp"


### PR DESCRIPTION
Allows to follow these instructions: https://github.com/AliceO2Group/QualityControl/blob/master/doc/Advanced.md#switch-detector-in-the-workflow-readout-dataflow