### PR TITLE
stfsender: force rc/dc connection, use SL 1 for Adaptive Routing

### DIFF
--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -23,6 +23,8 @@ command:
     - no_proxy=-ib,.internal
     - O2_DETECTOR={{ detector }}
     - UCX_NET_DEVICES=mlx5_0:1 # This limits StfSender to IB interface (used as of DD v1.3.0)
+    - UCX_TLS=sm,self,dc,rc    # Force dc/rc connection (used as of DD v1.4.0)
+    - UCX_IB_SL=1              # Force IB SL1 with Adaptive Routing (AR)
     - O2_PARTITION={{ environment_id }}
   log: "{{ log_task_output }}"
   shell: true


### PR DESCRIPTION
Hi @vascobarroso, can you provide this as an additional branch to the current FLPSuite. These options are required to test new network settings from PRODUCTION.
The existing options are enough for nominal running.
Thanks