### PR TITLE
MCH: changed remotePort for errors task

### DIFF
--- a/scripts/etc/mch-qcmn-epn-digits.json
+++ b/scripts/etc/mch-qcmn-epn-digits.json
@@ -56,7 +56,7 @@
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [ "epn" ],
-        "remotePort": "47790",
+        "remotePort": "47791",
         "remoteMachine": "alio2-cr1-qc01.cern.ch"
       }
     },


### PR DESCRIPTION
The remote port number is changed from 47790 (already in use for the digits task) to 47791, which is currently unused.