### PR TITLE
Use alternative SHM segment for DD tasks

### DIFF
--- a/tasks/stfbuilder.yaml
+++ b/tasks/stfbuilder.yaml
@@ -38,6 +38,7 @@ command:
   value: "{{ len(modulepath)>0 ? _module_cmdline : _plain_cmdline }}"
   arguments:
     - "--session=default"
+    - "--shm-segment-id=2"
     - "--transport=shmem"
     - "--monitoring-backend='{{ monitoring_dd_url }}'"
     - "--discovery-partition={{ environment_id }}"

--- a/tasks/stfbuilder.yaml
+++ b/tasks/stfbuilder.yaml
@@ -39,6 +39,7 @@ command:
   arguments:
     - "--session=default"
     - "--shm-segment-id=2"
+    - "--shm-segment-size=134217728"
     - "--transport=shmem"
     - "--monitoring-backend='{{ monitoring_dd_url }}'"
     - "--discovery-partition={{ environment_id }}"

--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -33,6 +33,7 @@ command:
   arguments:
     - "--session=default"
     - "--shm-segment-id=2"
+    - "--shm-segment-size=134217728"
     - "--transport=shmem"
     - "--input-channel-name={{ stfs_input_channel_name }}"
     - "--severity={{ fmq_severity }}"

--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -32,6 +32,7 @@ command:
   value: "{{ len(modulepath)>0 ? _module_cmdline : _plain_cmdline }}"
   arguments:
     - "--session=default"
+    - "--shm-segment-id=2"
     - "--transport=shmem"
     - "--input-channel-name={{ stfs_input_channel_name }}"
     - "--severity={{ fmq_severity }}"


### PR DESCRIPTION
This is separate DD from other DPL managed shm segments. With such configuration, DD tasks don't have to be configured with the same SHM-size option as the rest of FLP workflows.
https://alice.its.cern.ch/jira/browse/R3C-854