### PR TITLE
Change port number in MCH workflows (#319)

### DIFF
--- a/tasks/mch-qcmn-epn-digits-remote-MCH-QcTaskMCHErrors-proxy.yaml
+++ b/tasks/mch-qcmn-epn-digits-remote-MCH-QcTaskMCHErrors-proxy.yaml
@@ -25,7 +25,7 @@ bind:
     transport: zeromq
     addressing: tcp
     rateLogging: "{{ fmq_rate_logging }}"
-    target: "tcp://*:47790"
+    target: "tcp://*:47791"
 command:
   shell: true
   log: "{{ log_task_output }}"

--- a/workflows/mch-qcmn-epn-digits-remote.yaml
+++ b/workflows/mch-qcmn-epn-digits-remote.yaml
@@ -53,7 +53,7 @@ roles:
       transport: zeromq
       addressing: tcp
       rateLogging: "{{ fmq_rate_logging }}"
-      target: "tcp://*:47790"
+      target: "tcp://*:47791"
     task:
       load: mch-qcmn-epn-digits-remote-MCH-QcTaskMCHErrors-proxy
   - name: "MCH-MERGER-QcTaskMCHDigits1l-0"


### PR DESCRIPTION
* [MCH] changed remotePort for errors task

The remote port number is changed from 47790 (already in use for the
digits task) to 47791, which is currently unused.

* regenerate MCH workflows after port number change

Co-authored-by: aferrero2707 <aferrero1975@gmail.com>
Co-authored-by: Nomad user <root@alio2-cr1-mvs03.cern.ch>