### PR TITLE
PHS: Add  phos-raw-clusters-epn workflow to generate-all-workflows scripts

### DIFF
--- a/scripts/generate-all-dpl-workflows.sh
+++ b/scripts/generate-all-dpl-workflows.sh
@@ -106,6 +106,7 @@ check_pwd
 ./phos-compressor-raw-qcmnt3.sh
 ./phos-compressort3.sh
 ./phos-raw-clusters.sh
+./phos-raw-clusters-epn.sh
 ./qc-daq.sh
 ./qcmn-daq.sh
 ./tof-compressor.sh

--- a/tasks/phos-raw-clusters-epn-remote-PHS-ClusterTask-proxy.yaml
+++ b/tasks/phos-raw-clusters-epn-remote-PHS-ClusterTask-proxy.yaml
@@ -1,4 +1,4 @@
-name: phos-raw-clusters-epn-remote-internal-dpl-clock
+name: phos-raw-clusters-epn-remote-PHS-ClusterTask-proxy
 defaults:
   log_task_output: none
   exit_transition_timeout: 15
@@ -13,34 +13,19 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_internal-dpl-clock_to_PHS-ClusterTask-proxy
+  - name: from_PHS-ClusterTask-proxy_to_PHS-MERGER-ClusterTask1l-0
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
     sndBufSize: 4
     rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-RawTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
+  - name: PHS-ClusterTask-proxy
+    type: sub
+    transport: zeromq
+    addressing: tcp
     rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
+    target: "tcp://*:47758"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -70,7 +55,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'internal-dpl-clock'"
+    - "'PHS-ClusterTask-proxy'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -146,3 +131,13 @@ command:
     - "-1"
     - "--workflow-suffix"
     - "''"
+    - "--end-value-enumeration"
+    - "-1"
+    - "--orbit-multiplier-enumeration"
+    - "'0'"
+    - "--orbit-offset-enumeration"
+    - "'0'"
+    - "--start-value-enumeration"
+    - "'0'"
+    - "--step-value-enumeration"
+    - "'1'"

--- a/tasks/phos-raw-clusters-epn-remote-PHS-MERGER-ClusterTask1l-0.yaml
+++ b/tasks/phos-raw-clusters-epn-remote-PHS-MERGER-ClusterTask1l-0.yaml
@@ -1,4 +1,4 @@
-name: phos-raw-clusters-epn-remote-internal-dpl-clock
+name: phos-raw-clusters-epn-remote-PHS-MERGER-ClusterTask1l-0
 defaults:
   log_task_output: none
   exit_transition_timeout: 15
@@ -13,28 +13,7 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_internal-dpl-clock_to_PHS-ClusterTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-RawTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0
+  - name: from_PHS-MERGER-ClusterTask1l-0_to_qc-check-sink-QC_ClusterTask_0
     type: push
     transport: shmem
     addressing: ipc
@@ -70,7 +49,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'internal-dpl-clock'"
+    - "'PHS-MERGER-ClusterTask1l-0'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -146,3 +125,5 @@ command:
     - "-1"
     - "--workflow-suffix"
     - "''"
+    - "--period-timer-publish"
+    - "'30000000'"

--- a/tasks/phos-raw-clusters-epn-remote-PHS-MERGER-RawTask1l-0.yaml
+++ b/tasks/phos-raw-clusters-epn-remote-PHS-MERGER-RawTask1l-0.yaml
@@ -1,4 +1,4 @@
-name: phos-raw-clusters-epn-remote-internal-dpl-clock
+name: phos-raw-clusters-epn-remote-PHS-MERGER-RawTask1l-0
 defaults:
   log_task_output: none
   exit_transition_timeout: 15
@@ -13,28 +13,7 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_internal-dpl-clock_to_PHS-ClusterTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-RawTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0
+  - name: from_PHS-MERGER-RawTask1l-0_to_qc-check-sink-QC_RawTask_0
     type: push
     transport: shmem
     addressing: ipc
@@ -70,7 +49,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'internal-dpl-clock'"
+    - "'PHS-MERGER-RawTask1l-0'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -146,3 +125,5 @@ command:
     - "-1"
     - "--workflow-suffix"
     - "''"
+    - "--period-timer-publish"
+    - "'30000000'"

--- a/tasks/phos-raw-clusters-epn-remote-PHS-RawTask-proxy.yaml
+++ b/tasks/phos-raw-clusters-epn-remote-PHS-RawTask-proxy.yaml
@@ -1,4 +1,4 @@
-name: phos-raw-clusters-epn-remote-internal-dpl-clock
+name: phos-raw-clusters-epn-remote-PHS-RawTask-proxy
 defaults:
   log_task_output: none
   exit_transition_timeout: 15
@@ -13,34 +13,19 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_internal-dpl-clock_to_PHS-ClusterTask-proxy
+  - name: from_PHS-RawTask-proxy_to_PHS-MERGER-RawTask1l-0
     type: push
     transport: shmem
     addressing: ipc
     rateLogging: "{{ fmq_rate_logging }}"
     sndBufSize: 4
     rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-RawTask-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
+  - name: PHS-RawTask-proxy
+    type: sub
+    transport: zeromq
+    addressing: tcp
     rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
+    target: "tcp://*:47757"
 command:
   shell: true
   log: "{{ log_task_output }}"
@@ -70,7 +55,7 @@ command:
     - "--resources-monitoring"
     - "'{{ resources_monitoring }}'"
     - "--id"
-    - "'internal-dpl-clock'"
+    - "'PHS-RawTask-proxy'"
     - "--shm-monitor"
     - "'false'"
     - "--log-color"
@@ -146,3 +131,13 @@ command:
     - "-1"
     - "--workflow-suffix"
     - "''"
+    - "--end-value-enumeration"
+    - "-1"
+    - "--orbit-multiplier-enumeration"
+    - "'0'"
+    - "--orbit-offset-enumeration"
+    - "'0'"
+    - "--start-value-enumeration"
+    - "'0'"
+    - "--step-value-enumeration"
+    - "'1'"

--- a/workflows/phos-raw-clusters-epn-remote.yaml
+++ b/workflows/phos-raw-clusters-epn-remote.yaml
@@ -20,84 +20,84 @@ roles:
     connect:
     task:
       load: phos-raw-clusters-epn-remote-internal-dpl-clock
-  - name: "ClusterTask-proxy"
+  - name: "PHS-ClusterTask-proxy"
     connect:
-    - name: from_internal-dpl-clock_to_ClusterTask-proxy
+    - name: from_internal-dpl-clock_to_PHS-ClusterTask-proxy
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_ClusterTask-proxy"
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_PHS-ClusterTask-proxy"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
     bind:
-    - name: ClusterTask-proxy
+    - name: PHS-ClusterTask-proxy
       type: sub
       transport: zeromq
       addressing: tcp
       rateLogging: "{{ fmq_rate_logging }}"
       target: "tcp://*:47758"
     task:
-      load: phos-raw-clusters-epn-remote-ClusterTask-proxy
-  - name: "RawTask-proxy"
+      load: phos-raw-clusters-epn-remote-PHS-ClusterTask-proxy
+  - name: "PHS-RawTask-proxy"
     connect:
-    - name: from_internal-dpl-clock_to_RawTask-proxy
+    - name: from_internal-dpl-clock_to_PHS-RawTask-proxy
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_RawTask-proxy"
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_PHS-RawTask-proxy"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
     bind:
-    - name: RawTask-proxy
+    - name: PHS-RawTask-proxy
       type: sub
       transport: zeromq
       addressing: tcp
       rateLogging: "{{ fmq_rate_logging }}"
       target: "tcp://*:47757"
     task:
-      load: phos-raw-clusters-epn-remote-RawTask-proxy
-  - name: "MERGER-ClusterTask1l-0"
+      load: phos-raw-clusters-epn-remote-PHS-RawTask-proxy
+  - name: "PHS-MERGER-ClusterTask1l-0"
     connect:
-    - name: from_internal-dpl-clock_to_MERGER-ClusterTask1l-0
+    - name: from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_MERGER-ClusterTask1l-0"
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_PHS-MERGER-ClusterTask1l-0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
-    - name: from_ClusterTask-proxy_to_MERGER-ClusterTask1l-0
+    - name: from_PHS-ClusterTask-proxy_to_PHS-MERGER-ClusterTask1l-0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.ClusterTask-proxy:from_ClusterTask-proxy_to_MERGER-ClusterTask1l-0"
+      target: "{{ Parent().Path }}.PHS-ClusterTask-proxy:from_PHS-ClusterTask-proxy_to_PHS-MERGER-ClusterTask1l-0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
     task:
-      load: phos-raw-clusters-epn-remote-MERGER-ClusterTask1l-0
-  - name: "MERGER-RawTask1l-0"
+      load: phos-raw-clusters-epn-remote-PHS-MERGER-ClusterTask1l-0
+  - name: "PHS-MERGER-RawTask1l-0"
     connect:
-    - name: from_internal-dpl-clock_to_MERGER-RawTask1l-0
+    - name: from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_MERGER-RawTask1l-0"
+      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_PHS-MERGER-RawTask1l-0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
-    - name: from_RawTask-proxy_to_MERGER-RawTask1l-0
+    - name: from_PHS-RawTask-proxy_to_PHS-MERGER-RawTask1l-0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.RawTask-proxy:from_RawTask-proxy_to_MERGER-RawTask1l-0"
+      target: "{{ Parent().Path }}.PHS-RawTask-proxy:from_PHS-RawTask-proxy_to_PHS-MERGER-RawTask1l-0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
     task:
-      load: phos-raw-clusters-epn-remote-MERGER-RawTask1l-0
+      load: phos-raw-clusters-epn-remote-PHS-MERGER-RawTask1l-0
   - name: "qc-check-sink-QC_ClusterTask_0"
     connect:
-    - name: from_MERGER-ClusterTask1l-0_to_qc-check-sink-QC_ClusterTask_0
+    - name: from_PHS-MERGER-ClusterTask1l-0_to_qc-check-sink-QC_ClusterTask_0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.MERGER-ClusterTask1l-0:from_MERGER-ClusterTask1l-0_to_qc-check-sink-QC_ClusterTask_0"
+      target: "{{ Parent().Path }}.PHS-MERGER-ClusterTask1l-0:from_PHS-MERGER-ClusterTask1l-0_to_qc-check-sink-QC_ClusterTask_0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4
@@ -105,10 +105,10 @@ roles:
       load: phos-raw-clusters-epn-remote-qc-check-sink-QC_ClusterTask_0
   - name: "qc-check-sink-QC_RawTask_0"
     connect:
-    - name: from_MERGER-RawTask1l-0_to_qc-check-sink-QC_RawTask_0
+    - name: from_PHS-MERGER-RawTask1l-0_to_qc-check-sink-QC_RawTask_0
       type: pull
       transport: shmem
-      target: "{{ Parent().Path }}.MERGER-RawTask1l-0:from_MERGER-RawTask1l-0_to_qc-check-sink-QC_RawTask_0"
+      target: "{{ Parent().Path }}.PHS-MERGER-RawTask1l-0:from_PHS-MERGER-RawTask1l-0_to_qc-check-sink-QC_RawTask_0"
       rateLogging: "{{ fmq_rate_logging }}"
       sndBufSize: 4
       rcvBufSize: 4


### PR DESCRIPTION
Hello! 
It appeared that scripts/phos-raw-clusters-epn.sh was missing in scripts/generate-all-workflows.sh and was not regenerated in the flpsuite v0.57.0. This commit fixes the issue.