### PR TITLE
[EMCAL-718] Add tag "EMCAL" to task configuration

### DIFF
--- a/scripts/etc/emc-qcmn-epn.json
+++ b/scripts/etc/emc-qcmn-epn.json
@@ -27,8 +27,9 @@
             }
         },
         "tasks": {
-            "CellTask": {
+            "CellTaskEMCAL": {
                 "active": "true",
+                "task": "CellTask",
                 "className": "o2::quality_control_modules::emcal::CellTask",
                 "moduleName": "QcEMCAL",
                 "detectorName": "EMC",
@@ -52,8 +53,9 @@
             }
         },
         "checks": {
-            "CellCheckAmplitude": {
+            "CellCheckAmplitudeEMCAL": {
 			    "active": "true",
+                "check": "CheckAmplitude",
 			    "className": "o2::quality_control_modules::emcal::CellCheck",
 			    "moduleName": "QcEMCAL",
 			    "policy": "OnEachSeparately",

--- a/scripts/etc/emc-qcmn-epnall.json
+++ b/scripts/etc/emc-qcmn-epnall.json
@@ -27,8 +27,9 @@
 			}
 	    },
 	    "tasks": {
-			"RawTask": {
+			"RawTaskEMCAL": {
 			    "active": "true",
+				"taskName": "RawTask",
 			    "className": "o2::quality_control_modules::emcal::RawTask",
 			    "moduleName": "QcEMCAL",
 			    "detectorName": "EMC",
@@ -47,8 +48,9 @@
 			    "mergingMode": "delta",
 			    "localControl": "odc"
 			},
-			"CellTask": {
+			"CellTaskEMCAL": {
 			    "active": "true",
+				"taskName": "CellTask",
 			    "className": "o2::quality_control_modules::emcal::CellTask",
 			    "moduleName": "QcEMCAL",
 			    "detectorName": "EMC",
@@ -72,8 +74,9 @@
 			}
 	    },
 	    "checks": {
-			"RawBunchMinAmplitude": {
+			"RawBunchMinAmplitudeEMCAL": {
 				"active": "true",
+				"checkName": "RawBunchMinAmplitude",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -93,8 +96,9 @@
 					}
 				]
 			},
-			"RawErrorCheck": {
+			"RawErrorCheckEMCAL": {
 				"active": "true",
+				"checkName": "RawErrorCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -106,8 +110,9 @@
 					}
 				]
 			},
-			"RawPayloadCheck": {
+			"RawPayloadCheckEMCAL": {
 				"active": "true",
+				"checkName": "RawPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -122,8 +127,9 @@
 					}
 				]
 			},
-			"FECPayloadCheck": {
+			"FECPayloadCheckEMCAL": {
 				"active": "true",
+				"checkName": "FECPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -137,8 +143,9 @@
 					}
 				]
 			},
-			"CellCheckAmplitude": {
+			"CellCheckAmplitudeEMCAL": {
 			    "active": "true",
+				"checkName": "CellCheckAmplitude",
 			    "className": "o2::quality_control_modules::emcal::CellCheck",
 			    "moduleName": "QcEMCAL",
 			    "policy": "OnEachSeparately",

--- a/scripts/etc/emc-qcmn-flp.json
+++ b/scripts/etc/emc-qcmn-flp.json
@@ -27,8 +27,9 @@
             }
         },
         "tasks": {
-            "RawTask": {
+            "RawTaskEMCAL": {
                 "active": "true",
+                "taskName": "RawTask",
                 "className": "o2::quality_control_modules::emcal::RawTask",
                 "moduleName": "QcEMCAL",
                 "detectorName": "EMC",
@@ -48,8 +49,9 @@
             }
         },
         "checks": {
-			"RawBunchMinAmplitude": {
+			"RawBunchMinAmplitudeEMCAL": {
 				"active": "true",
+                "checkName": "RawBunchMinAmplitude",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -69,8 +71,9 @@
 					}
 				]
 			},
-            "RawErrorCheck": {
+            "RawErrorCheckEMCAL": {
 				"active": "true",
+                "checkName": "RawErrorCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -82,8 +85,9 @@
 					}
 				]
 			},
-            "RawPayloadCheck": {
+            "RawPayloadCheckEMCAL": {
 				"active": "true",
+                "checkName": "RawPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -98,8 +102,9 @@
 					}
 				]
 			},
-			"FECPayloadCheck": {
+			"FECPayloadCheckEMCAL": {
 				"active": "true",
+                "checkName": "FECPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",

--- a/scripts/etc/emc-qcmn-flpepn.json
+++ b/scripts/etc/emc-qcmn-flpepn.json
@@ -27,8 +27,9 @@
             }
         },
         "tasks": {
-            "RawTask": {
+            "RawTaskEMCAL": {
                 "active": "true",
+                "taskName": "RawTask",
                 "className": "o2::quality_control_modules::emcal::RawTask",
                 "moduleName": "QcEMCAL",
                 "detectorName": "EMC",
@@ -46,8 +47,9 @@
                 "remotePort": "47702",
                 "mergingMode": "delta"
             },
-            "CellTask": {
+            "CellTaskEMCAL": {
                 "active": "true",
+                "taskName": "CellTask",
                 "className": "o2::quality_control_modules::emcal::CellTask",
                 "moduleName": "QcEMCAL",
                 "detectorName": "EMC",
@@ -71,8 +73,9 @@
             }
         },
         "checks": {
-            "RawBunchMinAmplitude": {
+            "RawBunchMinAmplitudeEMCAL": {
 				"active": "true",
+                "checkName": "RawBunchMinAmplitude",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -92,8 +95,9 @@
 					}
 				]
 			},
-            "RawErrorCheck": {
+            "RawErrorCheckEMCAL": {
 				"active": "true",
+                "checkName": "RawErrorCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -105,8 +109,9 @@
 					}
 				]
 			},
-            "RawPayloadCheck": {
+            "RawPayloadCheckEMCAL": {
 				"active": "true",
+                "checkName": "RawPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -121,8 +126,9 @@
 					}
 				]
 			},
-			"FECPayloadCheck": {
+			"FECPayloadCheckEMCAL": {
 				"active": "true",
+                "checkName": "FECPayloadCheck",
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
@@ -136,8 +142,9 @@
 					}
 				]
 			},
-            "CellCheckAmplitude": {
+            "CellCheckAmplitudeEMCAL": {
 			    "active": "true",
+                "checkName": "CellCheckAmplitude",
 			    "className": "o2::quality_control_modules::emcal::CellCheck",
 			    "moduleName": "QcEMCAL",
 			    "policy": "OnEachSeparately",


### PR DESCRIPTION
This prevents naming clashes on the EPN when
the QC config is merged with other detectors.
The key "taskName" is assigned the name of the
task originally used.