### PR TITLE
[OCTRL-667] Trigger ccdb.RunStop at any transition from RUNNING

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1745,7 +1745,7 @@ roles:
       - name: stop
         call:
           func: ccdb.RunStop()
-          trigger: before_STOP_ACTIVITY
+          trigger: leave_RUNNING
           timeout: 10s
           critical: false
   - name: bookkeeping


### PR DESCRIPTION
If STOP_ACTIVITY is used, we do not get triggered if a run goes to ERROR.

Needs https://github.com/AliceO2Group/Control/pull/377 !