### PR TITLE
[EMCAL-711] Add remote workflow for RawDataErrors

### DIFF
--- a/scripts/emc-qcmn-epnall-rawerrors.sh
+++ b/scripts/emc-qcmn-epnall-rawerrors.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# set -x;
+set -e;
+set -u;
+
+source helpers.sh
+
+QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/emc-qcmn-epnall-rawerrors.json'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-epnall-rawerrors'
+QC_CONFIG_PARAM='qc_config_uri'
+
+cd ..
+
+WF_NAME=emc-qcmn-epnall-rawerrors-remote
+export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
+
+o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
+
+# add the templated QC config file path
+ESCAPED_QC_FINAL_CONFIG_PATH=$(printf '%s\n' "$QC_FINAL_CONFIG_PATH" | sed -e 's/[\/&]/\\&/g')
+sed -i /defaults:/\ a\\\ \\\ "${QC_CONFIG_PARAM}":\ \""${ESCAPED_QC_FINAL_CONFIG_PATH}"\" workflows/${WF_NAME}.yaml
+
+# find and replace all usages of the QC config path which was used to generate the workflow
+ESCAPED_QC_GEN_CONFIG_PATH=$(printf '%s\n' "$QC_GEN_CONFIG_PATH" | sed -e 's/[]\/$*.^[]/\\&/g');
+sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME}-*
+

--- a/scripts/etc/emc-qcmn-epnall-rawerrors.json
+++ b/scripts/etc/emc-qcmn-epnall-rawerrors.json
@@ -1,0 +1,220 @@
+{
+	"qc": {
+	    "config": {
+			"database": {
+			    "implementation": "CCDB",
+			    "host": "ali-qcdb.cern.ch:8083",
+			    "username": "not_applicable",
+			    "password": "not_applicable",
+			    "name": "not_applicable"
+			},
+			"infologger": {
+				"filterDiscardDebug": "true",
+				"filterDiscardLevel": "1"
+			},
+			"Activity": {
+			    "number": "42",
+			    "type": "2"
+			},
+			"monitoring": {
+			    "url": "infologger:///debug?qc"
+			},
+			"consul": {
+			    "url": "http://consul-test.cern.ch:8500"
+			},
+			"conditionDB": {
+			    "url": "ccdb-test.cern.ch:8080"
+			}
+	    },
+	    "tasks": {
+			"RawTaskEMCAL": {
+			    "active": "true",
+				"taskName": "RawTask",
+			    "className": "o2::quality_control_modules::emcal::RawTask",
+			    "moduleName": "QcEMCAL",
+			    "detectorName": "EMC",
+			    "cycleDurationSeconds": "60",
+			    "maxNumberCycles": "-1",
+			    "dataSource": {
+			    	"type": "dataSamplingPolicy",
+			      "name": "emcrawdata"
+			    },
+			    "location": "local",
+			    "localMachines": [
+					"epn"
+			    ],
+			    "remoteMachine": "alio2-cr1-qc02.cern.ch",
+			    "remotePort": "47701",
+			    "mergingMode": "delta",
+			    "localControl": "odc"
+			},
+			"CellTaskEMCAL": {
+			    "active": "true",
+				"taskName": "CellTask",
+			    "className": "o2::quality_control_modules::emcal::CellTask",
+			    "moduleName": "QcEMCAL",
+			    "detectorName": "EMC",
+			    "cycleDurationSeconds": "60",
+			    "maxNumberCycles": "-1",
+			    "dataSource": {
+					"type": "dataSamplingPolicy",
+					"name": "emccells"
+			    },
+			    "taskParameters": {
+					"nothing": "rien"
+			    },
+			    "location": "local",
+			    "localMachines": [
+					"epn"
+			    ],
+			    "remoteMachine": "alio2-cr1-qc02.cern.ch",
+			    "remotePort": "47702",
+			    "mergingMode": "delta",
+			    "localControl": "odc"
+			},
+            "RawErrorTaskEMCAL": {
+			    "active": "true",
+				"taskName": "RawErrorTask",
+			    "className": "o2::quality_control_modules::emcal::RawErrorTask",
+			    "moduleName": "QcEMCAL",
+			    "detectorName": "EMC",
+			    "cycleDurationSeconds": "60",
+			    "maxNumberCycles": "-1",
+			    "dataSource": {
+					"type": "direct",
+					"query": "rawerrors:EMC/DECODERERR"
+			    },
+			    "taskParameters": {
+					"nothing": "rien"
+			    },
+			    "location": "local",
+			    "localMachines": [
+					"epn"
+			    ],
+			    "remoteMachine": "alio2-cr1-qc02.cern.ch",
+			    "remotePort": "47702",
+			    "mergingMode": "delta",
+			    "localControl": "odc"
+
+            }
+	    },
+	    "checks": {
+			"RawBunchMinAmplitudeEMCAL": {
+				"active": "true",
+				"checkName": "RawBunchMinAmplitude",
+				"className": "o2::quality_control_modules::emcal::RawCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "RawTaskEMCAL",
+						"MOs": ["BunchMinRawAmplitudeFull_PHYS", "BunchMinRawAmplitudeEMCAL_PHYS", "BunchMinRawAmplitudeDCAL_PHYS",
+								"BunchMinRawAmplitude_SM0_PHYS", "BunchMinRawAmplitude_SM1_PHYS", "BunchMinRawAmplitude_SM2_PHYS",
+								"BunchMinRawAmplitude_SM3_PHYS", "BunchMinRawAmplitude_SM4_PHYS", "BunchMinRawAmplitude_SM5_PHYS",
+								"BunchMinRawAmplitude_SM6_PHYS", "BunchMinRawAmplitude_SM7_PHYS", "BunchMinRawAmplitude_SM8_PHYS",
+								"BunchMinRawAmplitude_SM9_PHYS", "BunchMinRawAmplitude_SM10_PHYS", "BunchMinRawAmplitude_SM11_PHYS",
+								"BunchMinRawAmplitude_SM12_PHYS", "BunchMinRawAmplitude_SM13_PHYS", "BunchMinRawAmplitude_SM14_PHYS",
+								"BunchMinRawAmplitude_SM15_PHYS", "BunchMinRawAmplitude_SM16_PHYS", "BunchMinRawAmplitude_SM17_PHYS",
+								"BunchMinRawAmplitude_SM18_PHYS", "BunchMinRawAmplitude_SM19_PHYS"
+						]
+					}
+				]
+			},
+			"RawErrorCheckEMCAL": {
+				"active": "true",
+				"checkName": "RawErrorCheck",
+				"className": "o2::quality_control_modules::emcal::RawCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "RawTaskEMCAL",
+						"MOs": ["ErrorTypePerSM"]
+					}
+				]
+			},
+			"RawPayloadCheckEMCAL": {
+				"active": "true",
+				"checkName": "RawPayloadCheck",
+				"className": "o2::quality_control_modules::emcal::RawCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "RawTaskEMCAL",
+						"MOs": [
+							"PayloadSizePerDDL",
+							"PayloadSizeTFPerDDL"
+						]
+					}
+				]
+			},
+			"FECPayloadCheckEMCAL": {
+				"active": "true",
+				"checkName": "FECPayloadCheck",
+				"className": "o2::quality_control_modules::emcal::RawCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "RawTaskEMCAL",
+						"MOs": [
+							"FECidMaxChWithInput_perSM"
+						]
+					}
+				]
+			},
+			"CellCheckAmplitudeEMCAL": {
+			    "active": "true",
+				"checkName": "CellCheckAmplitude",
+			    "className": "o2::quality_control_modules::emcal::CellCheck",
+			    "moduleName": "QcEMCAL",
+			    "policy": "OnEachSeparately",
+			    "detectorName": "EMC",
+			    "dataSource": [
+					{
+					    "type": "Task",
+					    "name": "CellTaskEMCAL",
+					    "MOs": ["cellAmplitudeEMCAL_CAL", "cellAmplitudeEMCAL_PHYS", "cellAmplitudeDCAL_CAL", "cellAmplitudeDCAL_PHYS",
+								"cellAmplitude_CAL", "cellAmplitude_PHYS"	
+					    ]
+					}
+			    ]
+			}
+	    }
+	},
+	"dataSamplingPolicies": [
+	    {
+			"id": "emcrawdata",
+			"active": "true",
+			"machines": ["epn"],
+			"query": "readout:EMC/RAWDATA",
+			"samplingConditions": [
+			    {
+					"condition": "random",
+					"fraction": "0.01",
+					"seed": "1248"
+			    }
+			],
+			"blocking": "false"
+		},
+	 	{
+			"id": "emccells",
+			"active": "true",
+			"machines": ["epn"],
+			"query": "emcal-cells:EMC/CELLS;emcal-triggerecords:EMC/CELLSTRGR",
+			"samplingConditions": [
+			    {
+					"condition": "random",
+					"fraction": "0.1",
+					"seed": "1248"
+				}
+			],
+			"blocking": "false"
+	    }
+	]
+}

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -136,6 +136,7 @@ defaults:
       - emc-qcmn-flp-remote
       - emc-qcmn-epn-remote
       - emc-qcmn-epnall-remote
+      - emc-qcmn-epnall-rawerrors-remote
       - emc-qcmn-flpepn-remote
       - qcmn-daq-remote
     visibleif: $$qc_remote_enabled === "true"    


### PR DESCRIPTION
Keep remote workflow for raw data errors separate for
the commissioning phase (as emc-qcmn-epnall-rawerrors-
remote). Once the workflow is tested and consul is adapted
it will be merged into emc-qcmn-epnall-remote and this
workflow will be removed again.