### PR TITLE
MFT: Unification of sh scripts and cycle length chage.

### DIFF
--- a/scripts/etc/mft-full-qcmn.json
+++ b/scripts/etc/mft-full-qcmn.json
@@ -44,7 +44,7 @@
         "className": "o2::quality_control_modules::mft::QcMFTDigitTask",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
-        "cycleDurationSeconds": "300",
+        "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
@@ -64,7 +64,7 @@
         "className": "o2::quality_control_modules::mft::QcMFTClusterTask",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
-        "cycleDurationSeconds": "300",
+        "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "dataSamplingPolicy",

--- a/scripts/etc/mft-track-full-qcmn.json
+++ b/scripts/etc/mft-track-full-qcmn.json
@@ -44,7 +44,7 @@
         "className": "o2::quality_control_modules::mft::QcMFTDigitTask",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
-        "cycleDurationSeconds": "300",
+        "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
@@ -64,7 +64,7 @@
         "className": "o2::quality_control_modules::mft::QcMFTClusterTask",
         "moduleName": "QcMFT",
         "detectorName": "MFT",
-        "cycleDurationSeconds": "300",
+        "cycleDurationSeconds": "60",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "dataSamplingPolicy",

--- a/scripts/mft-full-qcmn.sh
+++ b/scripts/mft-full-qcmn.sh
@@ -7,7 +7,6 @@ set -u;
 WF_NAME=mft-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
-DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn-{{ it }}'
 QC_CONFIG_PARAM='qc_config_uri'

--- a/scripts/mft-noise-qcmn.sh
+++ b/scripts/mft-noise-qcmn.sh
@@ -5,10 +5,11 @@ set -e;
 set -u;
 
 WF_NAME=mft-noise-qcmn-local
+export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-noise-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-noise-qcmn-{{ it }}'
 QC_CONFIG_PARAM='qc_config_uri'
-DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 DS_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-full-digits-sampling.json'
 DS_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-digits-sampling'

--- a/scripts/mft-track-full-qcmn.sh
+++ b/scripts/mft-track-full-qcmn.sh
@@ -7,7 +7,6 @@ set -u;
 WF_NAME=mft-track-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
-DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-track-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-track-full-qcmn-{{ it }}'
 QC_CONFIG_PARAM='qc_config_uri'


### PR DESCRIPTION
- Small changed to unify the sh script of MFT workflows in use.
- Shortening of the cycle length duration for digit and cluster task. Only until we have the option to make flexible cycle length duration, then we set it back to 5 minutes. 