### PR TITLE
Set DPL CCDB Fetcher global query rate (def:no re-check)

### DIFF
--- a/scripts/cpv-compressor.sh
+++ b/scripts/cpv-compressor.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-compressor
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/cpv-noise-calib-qc.sh
+++ b/scripts/cpv-noise-calib-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-noise-calib-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 # check

--- a/scripts/cpv-pedestal-calib-qc-expert.sh
+++ b/scripts/cpv-pedestal-calib-qc-expert.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-pedestal-calib-qc-expert
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 # check

--- a/scripts/cpv-pedestal-calib-qc.sh
+++ b/scripts/cpv-pedestal-calib-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-pedestal-calib-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 # check

--- a/scripts/cpv-physics-qcmn-epn.sh
+++ b/scripts/cpv-physics-qcmn-epn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=cpv-physics-qcmn-epn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/cpv-physics-testing.sh
+++ b/scripts/cpv-physics-testing.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-physics-testing
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/cpv-physics.sh
+++ b/scripts/cpv-physics.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-physics
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/cpv-qc-compressor.sh
+++ b/scripts/cpv-qc-compressor.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=cpv-qc-compressor
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 # check

--- a/scripts/datasampling-02.sh
+++ b/scripts/datasampling-02.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME='datasampling-02'
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/datasampling-02.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}

--- a/scripts/emc-qcmn-epn.sh
+++ b/scripts/emc-qcmn-epn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=emc-qcmn-epn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/emc-qcmn-epnall.sh
+++ b/scripts/emc-qcmn-epnall.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=emc-qcmn-epnall-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/emc-qcmn-local-flp.sh
+++ b/scripts/emc-qcmn-local-flp.sh
@@ -5,6 +5,7 @@ set -u;
 
 WF_NAME=emc-qcmn-flp-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/emc-qcmn-flp.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-flp'

--- a/scripts/emc-qcmn-remote-flp.sh
+++ b/scripts/emc-qcmn-remote-flp.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=emc-qcmn-flp-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/emc-qcmn-remote-flpepn.sh
+++ b/scripts/emc-qcmn-remote-flpepn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=emc-qcmn-flpepn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/fdd-digits-pipe-ds-qc-raw.sh
+++ b/scripts/fdd-digits-pipe-ds-qc-raw.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fdd-digits-pipe-ds-qc-raw
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fdd-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/fdd-digits-ds-qc-{{ it }}'

--- a/scripts/fdd-digits-pipe-ds-qc.sh
+++ b/scripts/fdd-digits-pipe-ds-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fdd-digits-pipe-ds-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fdd-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/fdd-digits-ds-qc-{{ it }}'

--- a/scripts/fdd-digits-pipe.sh
+++ b/scripts/fdd-digits-pipe.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fdd-digits-pipe
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 N_PIPELINES=10
 cd ..

--- a/scripts/fdd-digits-qc.sh
+++ b/scripts/fdd-digits-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fdd-digits-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fdd-digits-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/fdd-qc-post-processing.sh
+++ b/scripts/fdd-qc-post-processing.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=fdd-qc-post-processing-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/fdd-qcmn-remote.sh
+++ b/scripts/fdd-qcmn-remote.sh
@@ -13,6 +13,7 @@ QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=fdd-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/ft0-digits-pipe-ds-qc-raw.sh
+++ b/scripts/ft0-digits-pipe-ds-qc-raw.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=ft0-digits-pipe-ds-qc-raw
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/ft0-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/ft0-digits-ds-qc-{{ it }}'

--- a/scripts/ft0-digits-pipe-ds-qc.sh
+++ b/scripts/ft0-digits-pipe-ds-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=ft0-digits-pipe-ds-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/ft0-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/ft0-digits-ds-qc-{{ it }}'

--- a/scripts/ft0-digits-pipe.sh
+++ b/scripts/ft0-digits-pipe.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=ft0-digits-pipe
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 N_PIPELINES=10
 cd ..

--- a/scripts/ft0-digits-qc.sh
+++ b/scripts/ft0-digits-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=ft0-digits-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/ft0-digits-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/ft0-qc-post-processing.sh
+++ b/scripts/ft0-qc-post-processing.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=ft0-qc-post-processing-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/ft0-qcmn-remote.sh
+++ b/scripts/ft0-qcmn-remote.sh
@@ -13,6 +13,7 @@ QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=ft0-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/fv0-digits-pipe-ds-qc-raw.sh
+++ b/scripts/fv0-digits-pipe-ds-qc-raw.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fv0-digits-pipe-ds-qc-raw
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fv0-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/fv0-digits-ds-qc-{{ it }}'

--- a/scripts/fv0-digits-pipe-ds-qc.sh
+++ b/scripts/fv0-digits-pipe-ds-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fv0-digits-pipe-ds-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fv0-digits-ds-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/fv0-digits-ds-qc-{{ it }}'

--- a/scripts/fv0-digits-pipe.sh
+++ b/scripts/fv0-digits-pipe.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fv0-digits-pipe
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 N_PIPELINES=10
 cd ..

--- a/scripts/fv0-digits-qc.sh
+++ b/scripts/fv0-digits-qc.sh
@@ -6,6 +6,7 @@ set -u; # exit on undefined variable
 # Variables
 WF_NAME=fv0-digits-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/fv0-digits-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/fv0-qc-post-processing.sh
+++ b/scripts/fv0-qc-post-processing.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=fv0-qc-post-processing-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/fv0-qcmn-remote.sh
+++ b/scripts/fv0-qcmn-remote.sh
@@ -13,6 +13,7 @@ QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=fv0-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -55,6 +55,7 @@ function add_config_variable() {
   PARAM="$3"
   WF_NAME="$4"
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
   # add the templated variable

--- a/scripts/hmpid-raw-qc.sh
+++ b/scripts/hmpid-raw-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=hmpid-raw-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/hmpid-raw-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/hmpid_raw_qc-{{ it }}'

--- a/scripts/hmpid-raw-qcmn.sh
+++ b/scripts/hmpid-raw-qcmn.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=hmpid-raw-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/hmpid-raw-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/hmpid-raw-qcmn'
@@ -32,6 +33,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=hmpid-raw-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/hmpid-raw-to-pedestals.sh
+++ b/scripts/hmpid-raw-to-pedestals.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=hmpid-raw-to-pedestals
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/its-qc-fhr-fee-no-ds.sh
+++ b/scripts/its-qc-fhr-fee-no-ds.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=its-qc-fhr-fee-no-ds
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qc-fhr-fee-no-ds.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/its-qc-fhr-fee.sh
+++ b/scripts/its-qc-fhr-fee.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=its-qc-fhr-fee
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qc-fhr-fee.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/its-qcmn-cluster-track.sh
+++ b/scripts/its-qcmn-cluster-track.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-cluster-track-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-epn.sh
+++ b/scripts/its-qcmn-epn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-epn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-fee-epn.sh
+++ b/scripts/its-qcmn-fee-epn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-fee-epn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-fee-no-ds.sh
+++ b/scripts/its-qcmn-fee-no-ds.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=its-qcmn-fee-no-ds-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qcmn-fee-no-ds.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fee-no-ds-{{ it }}'
@@ -32,6 +33,7 @@ sed -i "s/alio2-cr1-flp187/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fee-no-ds'
 WF_NAME=its-qcmn-fee-no-ds-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-fhr-fee-no-ds-entire.sh
+++ b/scripts/its-qcmn-fhr-fee-no-ds-entire.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=its-qcmn-fhr-fee-no-ds-entire-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qcmn-fhr-fee-no-ds-entire.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-no-ds-entire-{{ it }}'
@@ -32,6 +33,7 @@ sed -i "s/alio2-cr1-flp187/{{ it }}/g" workflows/${WF_NAME}.yaml tasks/${WF_NAME
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-no-ds-entire'
 WF_NAME=its-qcmn-fhr-fee-no-ds-entire-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-fhr-fee-no-ds.sh
+++ b/scripts/its-qcmn-fhr-fee-no-ds.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=its-qcmn-fhr-fee-no-ds-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qcmn-fhr-fee-no-ds.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-no-ds-{{ it }}'
@@ -32,6 +33,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-no-ds'
 WF_NAME=its-qcmn-fhr-fee-no-ds-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-fhr-fee.sh
+++ b/scripts/its-qcmn-fhr-fee.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=its-qcmn-fhr-fee-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/its-qcmn-fhr-fee.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee-{{ it }}'
@@ -34,6 +35,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=its-qcmn-fhr-fee-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-flp-epn-no-ds-nocluster.sh
+++ b/scripts/its-qcmn-flp-epn-no-ds-nocluster.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-flp-epn-no-ds-nocluster-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-flp-epn-no-ds.sh
+++ b/scripts/its-qcmn-flp-epn-no-ds.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-flp-epn-no-ds-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/its-qcmn-flp-epn.sh
+++ b/scripts/its-qcmn-flp-epn.sh
@@ -14,6 +14,7 @@ cd ..
 
 WF_NAME=its-qcmn-flp-epn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mch-digits-epn.sh
+++ b/scripts/mch-digits-epn.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=mch-digits-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mch-qcmn-epn-digits.sh
+++ b/scripts/mch-qcmn-epn-digits.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=mch-qcmn-epn-digits-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mch-qcmn-epn-digits.json'
@@ -61,6 +62,7 @@ sed -i "s/""${ESCAPED_DS_GEN_CONFIG_PATH}""/{{ ""${DS_CONFIG_PARAM}"" }}/g" work
 
 WF_NAME=mch-qcmn-epn-digits-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mch-qcmn-epn-full.sh
+++ b/scripts/mch-qcmn-epn-full.sh
@@ -13,6 +13,7 @@ QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=mch-qcmn-epn-full-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/mch-qcmn-flp-digits.sh
+++ b/scripts/mch-qcmn-flp-digits.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=mch-qcmn-flp-digits-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mch-qcmn-flp-digits.json'
@@ -57,6 +58,7 @@ sed -i "s/""${ESCAPED_DS_GEN_CONFIG_PATH}""/{{ ""${DS_CONFIG_PARAM}"" }}/g" work
 
 WF_NAME=mch-qcmn-flp-digits-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-decoder.sh
+++ b/scripts/mft-decoder.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-decoder
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ../ 

--- a/scripts/mft-digits-qc.sh
+++ b/scripts/mft-digits-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-digits-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'${QUALITYCONTROL_ROOT}'/etc/qc-mft-digit.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/mft-full-qcmn.sh
+++ b/scripts/mft-full-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn-{{ it }}'

--- a/scripts/mft-noise-qcmn.sh
+++ b/scripts/mft-noise-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-noise-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-noise-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-noise-qcmn-{{ it }}'

--- a/scripts/mft-raw-cluster-qcmn.sh
+++ b/scripts/mft-raw-cluster-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-raw-cluster-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-cluster-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-raw-cluster-qcmn'
@@ -33,6 +34,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-raw-cluster-qcmn'
 WF_NAME=mft-raw-cluster-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-raw-digits-qc.sh
+++ b/scripts/mft-raw-digits-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-raw-digits-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-digits-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/mft-raw-direct-qcmn.sh
+++ b/scripts/mft-raw-direct-qcmn.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=mft-raw-direct-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-direct-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-raw-direct-qcmn'
@@ -32,6 +33,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=mft-raw-direct-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-raw-qc.sh
+++ b/scripts/mft-raw-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-raw-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'${QUALITYCONTROL_ROOT}'/etc/qc-mft-readout.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/'${WF_NAME}'-{{ it }}'

--- a/scripts/mft-raw-qcmn.sh
+++ b/scripts/mft-raw-qcmn.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=mft-raw-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-raw-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-raw-qcmn'
@@ -32,6 +33,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=mft-raw-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-test1-full-qcmn.sh
+++ b/scripts/mft-test1-full-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-test1-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn-{{ it }}'
@@ -45,6 +46,7 @@ sed -i "s/""${ESCAPED_DS_GEN_CONFIG_PATH}""/{{ ""${DS_CONFIG_PARAM}"" }}/g" work
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn'
 WF_NAME=mft-test1-full-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-test2-full-qcmn.sh
+++ b/scripts/mft-test2-full-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-test2-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn-{{ it }}'
@@ -45,6 +46,7 @@ sed -i "s/""${ESCAPED_DS_GEN_CONFIG_PATH}""/{{ ""${DS_CONFIG_PARAM}"" }}/g" work
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-full-qcmn'
 WF_NAME=mft-test2-full-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/mft-track-full-qcmn.sh
+++ b/scripts/mft-track-full-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=mft-track-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/mft-track-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mft-track-full-qcmn-{{ it }}'

--- a/scripts/mid-qcmn-epn-digits.sh
+++ b/scripts/mid-qcmn-epn-digits.sh
@@ -13,6 +13,7 @@ QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=mid-qcmn-epn-digits
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/mid-raw-decoder.sh
+++ b/scripts/mid-raw-decoder.sh
@@ -9,6 +9,7 @@ source helpers.sh
 
 WF_NAME=mid-raw-decoder
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 ARGS_ALL="-b --session default"

--- a/scripts/minimal-dpl.sh
+++ b/scripts/minimal-dpl.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=minimal-dpl
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/phos-compressor-raw-qc.sh
+++ b/scripts/phos-compressor-raw-qc.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=phos-compressor-raw-qc
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-compressor-raw-qc'

--- a/scripts/phos-compressor-raw-qcmn.sh
+++ b/scripts/phos-compressor-raw-qcmn.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=phos-compressor-raw-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-compressor-raw-qcmn'
@@ -39,6 +40,7 @@ sed -i '/--presamples/{n;s/.*/    - "{{ phos_presamples }}"/}' tasks/${WF_NAME}-
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=phos-compressor-raw-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/phos-compressor-raw-qcmnt3.sh
+++ b/scripts/phos-compressor-raw-qcmnt3.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=phos-compressor-raw-qcmnt3-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-compressor-raw-qcmn'
@@ -41,6 +42,7 @@ sed -i '/--presamples/{n;s/.*/    - "{{ phos_presamples }}"/}' tasks/${WF_NAME}-
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=phos-compressor-raw-qcmnt3-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/phos-compressor-raw-qct3.sh
+++ b/scripts/phos-compressor-raw-qct3.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=phos-compressor-raw-qct3
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-compressor-raw-qc.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-compressor-raw-qc'

--- a/scripts/phos-compressor.sh
+++ b/scripts/phos-compressor.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=phos-compressor
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/phos-compressort3.sh
+++ b/scripts/phos-compressort3.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=phos-compressort3
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/phos-raw-clusters.sh
+++ b/scripts/phos-raw-clusters.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=phos-raw-clusters-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/phos-raw-clusters-flpepn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/phos-raw-clusters-flpepn'
@@ -41,6 +42,7 @@ sed -i '/--presamples/{n;s/.*/    - "{{ phos_presamples }}"/}' tasks/${WF_NAME}-
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=phos-raw-clusters-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/qc-daq.sh
+++ b/scripts/qc-daq.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=qc-daq
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/qc-daq.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/stfb_to_daqtask-{{ it }}'

--- a/scripts/qcmn-daq.sh
+++ b/scripts/qcmn-daq.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=qcmn-daq-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/qcmn-daq.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq'
@@ -36,6 +37,7 @@ sed -i /defaults:/\ a\\\ \\\ "detector: TST" workflows/${WF_NAME}.yaml
 
 WF_NAME=qcmn-daq-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tof-compressor.sh
+++ b/scripts/tof-compressor.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=tof-compressor
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 cd ..

--- a/scripts/tof-full-epn-qcmn.sh
+++ b/scripts/tof-full-epn-qcmn.sh
@@ -5,6 +5,7 @@ set -e;
 set -u;
 
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/tof-full-epn-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/tof-full-epn-qcmn'
@@ -16,6 +17,7 @@ cd ../
 
 WF_NAME=tof-full-epn-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tof-full-qcmn.sh
+++ b/scripts/tof-full-qcmn.sh
@@ -6,6 +6,7 @@ set -u;
 
 WF_NAME=tof-full-qcmn-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/tof-full-qcmn.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/tof-full-qcmn'
@@ -35,6 +36,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=tof-full-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tof-qcmn-compressor.sh
+++ b/scripts/tof-qcmn-compressor.sh
@@ -8,6 +8,7 @@ source helpers.sh
 
 WF_NAME=tof-qcmn-compressor-local
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/tof-qcmn-compressor.json'
 QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/tof-qcmn-compressor'
@@ -33,6 +34,7 @@ sed -i "s/""${ESCAPED_QC_GEN_CONFIG_PATH}""/{{ ""${QC_CONFIG_PARAM}"" }}/g" work
 # QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/its-qcmn-fhr-fee'
 WF_NAME=tof-qcmn-compressor-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-full-nodummy-nopid-qcmn.sh
+++ b/scripts/tpc-full-nodummy-nopid-qcmn.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-full-nodummy-nopid-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-full-nodummy-noraw-qcmn.sh
+++ b/scripts/tpc-full-nodummy-noraw-qcmn.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-full-nodummy-noraw-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-full-nodummy-qcmn.sh
+++ b/scripts/tpc-full-nodummy-qcmn.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-full-nodummy-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-full-qcmn.sh
+++ b/scripts/tpc-full-qcmn.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-full-qcmn-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-idc.sh
+++ b/scripts/tpc-idc.sh
@@ -128,6 +128,7 @@ QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/a
 QC_CONFIG_PARAM='qc_config_uri'
 
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 

--- a/scripts/tpc-krypton-qcmn.sh
+++ b/scripts/tpc-krypton-qcmn.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-krypton-qcmn-remote # for krypton Clusters
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-qc-post-calib.sh
+++ b/scripts/tpc-qc-post-calib.sh
@@ -17,6 +17,7 @@ cd ../
 
 WF_NAME=tpc-qc-post-calib-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-qc-post-processing.sh
+++ b/scripts/tpc-qc-post-processing.sh
@@ -14,6 +14,7 @@ cd ../
 
 WF_NAME=tpc-qc-post-processing-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/tpc-qc-post-trending.sh
+++ b/scripts/tpc-qc-post-trending.sh
@@ -15,6 +15,7 @@ cd ../
 
 WF_NAME=tpc-qc-post-trending-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/trd-qcmn-nodigits.sh
+++ b/scripts/trd-qcmn-nodigits.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=trd-full-qcmn-nodigits-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/trd-qcmn-nopulseheight.sh
+++ b/scripts/trd-qcmn-nopulseheight.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=trd-full-qcmn-nopulseheight-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/trd-qcmn-norawdatastats.sh
+++ b/scripts/trd-qcmn-norawdatastats.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=trd-full-qcmn-norawdatastats-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/trd-qcmn-notracklets.sh
+++ b/scripts/trd-qcmn-notracklets.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=trd-full-qcmn-notracklets-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME

--- a/scripts/trd-qcmn.sh
+++ b/scripts/trd-qcmn.sh
@@ -20,6 +20,7 @@ cd ..
 
 WF_NAME=trd-full-qcmn-epn
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
+export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME


### PR DESCRIPTION
This sets `DPL_CONDITION_QUERY_RATE` to `GEN_TOPO_EPN_CCDB_QUERY_RATE` (or -1 if the later is not defined) at the topology generation level. With this setting the validity of already cached CCDB objects will not be checked anymore (unless particular object explicitly requires validity checks).
To recover old behaviour with per-TF CCDB query one should set set `GEN_TOPO_EPN_CCDB_QUERY_RATE=1` 

@davidrohr @martenole 