### PR TITLE
[EMCAL-792] Enable checkers for RawErrorTask for all histograms

### DIFF
--- a/scripts/etc/emc-qcmn-epn.json
+++ b/scripts/etc/emc-qcmn-epn.json
@@ -93,6 +93,22 @@
 					    ]
 					}
 			    ]
+			},
+            "RawDecodingErrorCheckEMCAL": {
+				"active": "true",
+				"className": "o2::quality_control_modules::emcal::RawErrorCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
+				"dataSource": [
+				  	{
+						"type": "Task",
+						"name": "RawErrorTaskEMCAL",
+						"MOs": ["RawDataErrors", "PageErrors", "MajorAltroErrors", "MinorAltroError", "RawFitError", "GeometryError", "GainTypeError",
+					  			"NoHGPerDDL", "NoLGPerDDL"
+						]
+				  	}
+				]
 			}
         }
     },

--- a/scripts/etc/emc-qcmn-epnall.json
+++ b/scripts/etc/emc-qcmn-epnall.json
@@ -104,6 +104,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -126,6 +127,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -140,6 +142,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -157,6 +160,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+			    "detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -183,6 +187,22 @@
 					    ]
 					}
 			    ]
+			},
+			"RawDecodingErrorCheckEMCAL": {
+				"active": "true",
+				"className": "o2::quality_control_modules::emcal::RawErrorCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
+				"dataSource": [
+				  	{
+						"type": "Task",
+						"name": "RawErrorTaskEMCAL",
+						"MOs": ["RawDataErrors", "PageErrors", "MajorAltroErrors", "MinorAltroError", "RawFitError", "GeometryError", "GainTypeError",
+					  			"NoHGPerDDL", "NoLGPerDDL"
+						]
+				  	}
+				]
 			}
 	    }
 	},

--- a/scripts/etc/emc-qcmn-flpepn.json
+++ b/scripts/etc/emc-qcmn-flpepn.json
@@ -103,6 +103,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -125,6 +126,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -139,6 +141,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -156,6 +159,7 @@
 				"className": "o2::quality_control_modules::emcal::RawCheck",
 				"moduleName": "QcEMCAL",
 				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
 				"dataSource": [
 					{
 						"type": "Task",
@@ -182,6 +186,22 @@
 					    ]
 					}
 			    ]
+			},
+            "RawDecodingErrorCheckEMCAL": {
+				"active": "true",
+				"className": "o2::quality_control_modules::emcal::RawErrorCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+                "detectorName": "EMC",
+				"dataSource": [
+				  	{
+						"type": "Task",
+						"name": "RawErrorTaskEMCAL",
+						"MOs": ["RawDataErrors", "PageErrors", "MajorAltroErrors", "MinorAltroError", "RawFitError", "GeometryError", "GainTypeError",
+					  			"NoHGPerDDL", "NoLGPerDDL"
+						]
+				  	}
+				]
 			}
         }
     },


### PR DESCRIPTION
Checking presence of error code and leaving detailed
messages about found error codes in the InfoLogger.
Checks are performed on all raw error histograms.
Checkers are enabled for remote workflows of all
workflows including processing on the EPN.