### PR TITLE
Keep full MID QC configuration but disable track check

### DIFF
--- a/scripts/etc/mid-full-qcmn.json
+++ b/scripts/etc/mid-full-qcmn.json
@@ -161,6 +161,20 @@
             "MOs": []
           }
         ]
+      },
+      "QcCheckMIDTracks": {
+        "active": "false",
+        "className": "o2::quality_control_modules::mid::TracksQcCheck",
+        "moduleName": "QcMID",
+        "detectorName": "MID",
+        "policy": "OnAny",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "QcTaskMIDTracks",
+            "MOs": []
+          }
+        ]
       }
     }
   },

--- a/scripts/mid-full-qcmn.sh
+++ b/scripts/mid-full-qcmn.sh
@@ -8,7 +8,7 @@ source helpers.sh
 
 WF_NAME=mid-full-qcmn-local
 QC_GEN_CONFIG_PATH='json://'$(pwd)'/etc/mid-full-qcmn.json'
-QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn-qcmn'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn_full-qcmn'
 QC_CONFIG_PARAM='qc_config_uri'
 
 cd ../

--- a/tasks/mid-full-qcmn-local-Dispatcher.yaml
+++ b/tasks/mid-full-qcmn-local-Dispatcher.yaml
@@ -84,7 +84,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-local-MID-QcTaskMIDRaw-proxy.yaml
+++ b/tasks/mid-full-qcmn-local-MID-QcTaskMIDRaw-proxy.yaml
@@ -70,7 +70,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-local-dpl-output-proxy.yaml
+++ b/tasks/mid-full-qcmn-local-dpl-output-proxy.yaml
@@ -81,7 +81,7 @@ command:
     - "--environment"
     - "'DPL_OUTPUT_PROXY_ORDERED=1'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-local-internal-dpl-clock.yaml
+++ b/tasks/mid-full-qcmn-local-internal-dpl-clock.yaml
@@ -89,7 +89,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-local-qc-task-MID-QcTaskMIDRaw.yaml
+++ b/tasks/mid-full-qcmn-local-qc-task-MID-QcTaskMIDRaw.yaml
@@ -79,7 +79,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-local-readout-proxy.yaml
+++ b/tasks/mid-full-qcmn-local-readout-proxy.yaml
@@ -82,7 +82,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDClust1l-0.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDClust1l-0.yaml
@@ -77,7 +77,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDDigits1l-0.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDDigits1l-0.yaml
@@ -77,7 +77,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDRaw1l-0.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDRaw1l-0.yaml
@@ -77,7 +77,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDTracks1l-0.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-MERGER-QcTaskMIDTracks1l-0.yaml
@@ -77,7 +77,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-QcTaskMIDClust-proxy.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-QcTaskMIDClust-proxy.yaml
@@ -84,7 +84,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-QcTaskMIDDigits-proxy.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-QcTaskMIDDigits-proxy.yaml
@@ -84,7 +84,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-QcTaskMIDRaw-proxy.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-QcTaskMIDRaw-proxy.yaml
@@ -84,7 +84,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-MID-QcTaskMIDTracks-proxy.yaml
+++ b/tasks/mid-full-qcmn-remote-MID-QcTaskMIDTracks-proxy.yaml
@@ -84,7 +84,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-internal-dpl-clock.yaml
+++ b/tasks/mid-full-qcmn-remote-internal-dpl-clock.yaml
@@ -126,7 +126,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-internal-dpl-injected-dummy-sink.yaml
+++ b/tasks/mid-full-qcmn-remote-internal-dpl-injected-dummy-sink.yaml
@@ -70,7 +70,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDClust.yaml
+++ b/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDClust.yaml
@@ -79,7 +79,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDDigits.yaml
+++ b/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDDigits.yaml
@@ -79,7 +79,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDRaw.yaml
+++ b/tasks/mid-full-qcmn-remote-qc-check-MID-QcCheckMIDRaw.yaml
@@ -79,7 +79,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/tasks/mid-full-qcmn-remote-qc-check-sink-QMID_QcTaskMIDTracks_0.yaml
+++ b/tasks/mid-full-qcmn-remote-qc-check-sink-QMID_QcTaskMIDTracks_0.yaml
@@ -72,7 +72,7 @@ command:
     - "--early-forward-policy"
     - "'never'"
     - "--fairmq-ipc-prefix"
-    - "'@'"
+    - "'/var/folders/m0/wgm2kwjd2vx292zzz25ctz3m0000gp/T/'"
     - "--fairmq-rate-logging"
     - "'0'"
     - "--fairmq-recv-buffer-size"

--- a/workflows/mid-full-qcmn-local.yaml
+++ b/workflows/mid-full-qcmn-local.yaml
@@ -3,7 +3,7 @@ vars:
   dpl_command: >-
     o2-dpl-raw-proxy -b --session default --dataspec 'A:MID/RAWDATA;x:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' | o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'A:MID/RAWDATA;x:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"' | o2-qc -b --config {{ qc_config_uri }} --local --host flp
 defaults:
-  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn-qcmn"
+  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn_full-qcmn"
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0

--- a/workflows/mid-full-qcmn-remote.yaml
+++ b/workflows/mid-full-qcmn-remote.yaml
@@ -3,7 +3,7 @@ vars:
   dpl_command: >-
     o2-qc --config {{ qc_config_uri }} --remote -b
 defaults:
-  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn-qcmn"
+  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mid-flp_raw-epn_full-qcmn"
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0


### PR DESCRIPTION
This PR is equivalent to https://github.com/AliceO2Group/ControlWorkflows/pull/419 and https://github.com/AliceO2Group/ControlWorkflows/pull/427 but, instead of pointing to a new json file on consul, it simply expects that the CheckMIDTracks is set to inactive.
This is expected to minimize the code modification when we will recover the check in the future.
The commits are meant to be atomic: please do not squash