### PR TITLE
MFT: Adding check on increasing of entries to all QC tasks for 1 plot and adding new trending plots

### DIFF
--- a/scripts/etc/mft-full-qcmn.json
+++ b/scripts/etc/mft-full-qcmn.json
@@ -97,7 +97,7 @@
         "dataSource": [{
           "type": "Task",
           "name": "MFTReadoutTask",
-            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
+          "MOs" : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
         }]
       },
       "MFTDigitCheck": {
@@ -109,7 +109,7 @@
         "dataSource": [{
           "type": "Task",
           "name": "MFTDigitTask",
-            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
+          "MOs" : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         }]
       },
       "MFTClusterCheck": {
@@ -123,6 +123,30 @@
         "moduleName": "QcMFT",
         "detectorName": "MFT",
         "policy": "OnAny"
+      },
+      "MFTIncrEntrCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnEachSeparately",
+        "detectorName": "MFT",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "MFTReadoutTask",
+            "MOs" : ["mSummaryChipError"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTDigitTask",
+            "MOs" : ["mDigitChipOccupancy"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTClusterTask",
+            "MOs" : ["mClusterOccupancy"]
+          }
+        ]
       }
     },
     "postprocessing": {
@@ -168,6 +192,123 @@
         ],
         "updateTrigger": [
           "newobject:qcdb:MFT/MO/MFTReadoutTask/mSummaryChipWarning"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "MFTOccupancyTrend": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mDigitEmptyChipsTrend",
+            "title": "Trend of total number of chips with no digits",
+            "varexp": "mDigitChipOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no digits:time"
+          },
+          {
+            "name": "mClusterEmptyChipsTrend",
+            "title": "Trend of total number of chips with no clusters",
+            "varexp": "mClusterOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no clusters:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:MFT/MO/MFTClusterTask/mClusterZ"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "MFTTrendSlices": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::SliceTrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "1", "468", "936" ] ],
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterPatternIndex" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "0", "4", "11", "300" ] ],
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mMeanDigitOccupancyPerHalfMFTTrend",
+            "title": "Mean digit occupancy trend for each MFT half",
+            "varexp": "mDigitChipOccupancy.meanY:multigraphtime",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanY:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean digit occupancy for H0 (blue) and H1 (yellow):time"
+          },
+          {
+            "name": "mClusterPatternIDMeanTrend",
+            "title": "Mean cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean cluster pattern ID:time"
+          },
+          {
+            "name": "mClusterPatternIDStdDevTrend",
+            "title": "StdDev of cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.stddevX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "StdDev of cluster pattern ID:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:MFT/MO/MFTClusterTask/mClusterZ"
         ],
         "stopTrigger": [
           "userorcontrol"

--- a/scripts/etc/mft-noise-qcmn.json
+++ b/scripts/etc/mft-noise-qcmn.json
@@ -94,11 +94,13 @@
           "FaultThresholdMedium" : "10",
           "FaultThresholdBad" : "20"
         },
-        "dataSource": [{
+        "dataSource": [
+          {
           "type": "Task",
           "name": "MFTReadoutTask",
-            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
-        }]
+          "MOs" : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
+          }
+        ]
       },
       "MFTDigitCheck": {
         "active": "true",
@@ -109,7 +111,7 @@
         "dataSource": [{
           "type": "Task",
           "name": "MFTDigitTask",
-            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
+          "MOs" : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         }]
       },
       "MFTClusterCheck": {
@@ -123,7 +125,26 @@
         "moduleName": "QcMFT",
         "detectorName": "MFT",
         "policy": "OnAny"
-      }
+      },
+      "MFTIncrEntrCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnEachSeparately",
+        "detectorName": "MFT",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "MFTReadoutTask",
+            "MOs" : ["mSummaryChipError"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTDigitTask",
+            "MOs" : ["mDigitChipOccupancy"]
+          }
+        ]
+      }      
     },
     "postprocessing": {
       "MFTReadoutTrend": {

--- a/scripts/etc/mft-noise-qcmn.json
+++ b/scripts/etc/mft-noise-qcmn.json
@@ -94,13 +94,11 @@
           "FaultThresholdMedium" : "10",
           "FaultThresholdBad" : "20"
         },
-        "dataSource": [
-          {
+        "dataSource": [{
           "type": "Task",
           "name": "MFTReadoutTask",
           "MOs" : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
-          }
-        ]
+        }]
       },
       "MFTDigitCheck": {
         "active": "true",

--- a/scripts/etc/mft-track-full-qcmn.json
+++ b/scripts/etc/mft-track-full-qcmn.json
@@ -116,7 +116,7 @@
         "dataSource": [{
           "type": "Task",
           "name": "MFTReadoutTask",
-            "MOs"  : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
+          "MOs" : ["mDDWSummary","mSummaryChipOk","mSummaryChipFault", "mSummaryChipError", "mSummaryChipWarning", "mRDHSummary"]
         }]
       },
       "MFTDigitCheck": {
@@ -128,7 +128,7 @@
         "dataSource": [{
           "type": "Task",
           "name": "MFTDigitTask",
-            "MOs"  : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
+          "MOs" : ["mDigitChipOccupancy","mDigitOccupancySummary","mDigitChipStdDev"]
         }]
       },
       "MFTClusterCheck": {
@@ -142,6 +142,35 @@
         "moduleName": "QcMFT",
         "detectorName": "MFT",
         "policy": "OnAny"
+      },
+      "MFTIncrEntrCheck": {
+        "active": "true",
+        "className": "o2::quality_control_modules::common::IncreasingEntries",
+        "moduleName": "QcCommon",
+        "policy": "OnEachSeparately",
+        "detectorName": "MFT",
+        "dataSource": [
+          {
+            "type": "Task",
+            "name": "MFTReadoutTask",
+            "MOs" : ["mSummaryChipError"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTDigitTask",
+            "MOs" : ["mDigitChipOccupancy"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTClusterTask",
+            "MOs" : ["mClusterOccupancy"]
+          },
+          {
+            "type": "Task",
+            "name": "MFTAsyncTask",
+            "MOs" : ["mTrackROFNEntries"]
+          }
+        ]
       }
     },
     "postprocessing": {
@@ -187,6 +216,123 @@
         ],
         "updateTrigger": [
           "newobject:qcdb:MFT/MO/MFTReadoutTask/mSummaryChipWarning"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "MFTOccupancyTrend": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::TrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterOccupancy" ],
+            "reductorName": "o2::quality_control_modules::mft::QcMFTOccupancyTrend",
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mDigitEmptyChipsTrend",
+            "title": "Trend of total number of chips with no digits",
+            "varexp": "mDigitChipOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no digits:time"
+          },
+          {
+            "name": "mClusterEmptyChipsTrend",
+            "title": "Trend of total number of chips with no clusters",
+            "varexp": "mClusterOccupancy.binContentOverflow:time",
+            "selection": "",
+            "option": "*L",
+            "graphAxisLabel": "Chips with no clusters:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:MFT/MO/MFTClusterTask/mClusterZ"
+        ],
+        "stopTrigger": [
+          "userorcontrol"
+        ]
+      },
+      "MFTTrendSlices": {
+        "active": "true",
+        "className": "o2::quality_control::postprocessing::SliceTrendingTask",
+        "moduleName": "QcMFT",
+        "detectorName": "MFT",
+        "dataSources": [
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTDigitTask",
+            "names": [ "mDigitChipOccupancy" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "1", "468", "936" ] ],
+            "moduleName": "QcMFT"
+          },
+          {
+            "type": "repository",
+            "path": "MFT/MO/MFTClusterTask",
+            "names": [ "mClusterPatternIndex" ],
+            "reductorName": "o2::quality_control_modules::common::TH1SliceReductor",
+            "axisDivision": [ [ "0", "4", "11", "300" ] ],
+            "moduleName": "QcMFT"
+          }
+        ],
+        "plots": [
+          {
+            "name": "mMeanDigitOccupancyPerHalfMFTTrend",
+            "title": "Mean digit occupancy trend for each MFT half",
+            "varexp": "mDigitChipOccupancy.meanY:multigraphtime",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanY:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean digit occupancy for H0 (blue) and H1 (yellow):time"
+          },
+          {
+            "name": "mClusterPatternIDMeanTrend",
+            "title": "Mean cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.meanX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "Mean cluster pattern ID:time"
+          },
+          {
+            "name": "mClusterPatternIDStdDevTrend",
+            "title": "StdDev of cluster pattern ID trend for different regions",
+            "varexp": "mClusterPatternIndex.stddevX:time",
+            "selection": "",
+            "option": "*L",
+            "graphErrors": "errMeanX:0.5",
+            "graphYRange": "",
+            "graphXRange": "",
+            "graphAxisLabel": "StdDev of cluster pattern ID:time"
+          }
+        ],
+        "initTrigger": [
+          "userorcontrol"
+        ],
+        "updateTrigger": [
+          "newobject:qcdb:MFT/MO/MFTClusterTask/mClusterZ"
         ],
         "stopTrigger": [
           "userorcontrol"


### PR DESCRIPTION
- Check on increasing entries added to 1 plot from each task
- Added trending plots for Cluster and Digit for empty chips
- Added trending plot slices for H0 and H1 of MFT for digit occupancy
- Added trending plot slices for cluster pattern ID mean and std dev in 3 ranges of ID