### PR TITLE
[EMCAL-524, EMCAL-526] Enable checkers for occupancy histograms

### DIFF
--- a/scripts/etc/emc-qcmn-epn.json
+++ b/scripts/etc/emc-qcmn-epn.json
@@ -99,6 +99,29 @@
                     }
                 ]
             },
+            "CheckCellOccupancyEMCAL": {
+				"active": "true",
+				"checkName": "CellCheckOccupancy",
+				"className": "o2::quality_control_modules::emcal::CellCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "CellTaskEMCAL",
+						"MOs": [
+							"cellOccupancyEMC_PHYS",
+							"cellOccupancyEMCwThrBelow_PHYS",
+							"cellOccupancyEMCwThr_PHYS",
+							"cellOccupancyInt_PHYS",
+							"cellOccupancyEMC_CAL",
+							"cellOccupancyEMCwThrBelow_CAL",
+							"cellOccupancyInt_CAL"
+						]
+					}
+				]
+			},
             "RawDecodingErrorCheckEMCAL": {
                 "active": "true",
                 "className": "o2::quality_control_modules::emcal::RawErrorCheck",

--- a/scripts/etc/emc-qcmn-epnall.json
+++ b/scripts/etc/emc-qcmn-epnall.json
@@ -208,6 +208,30 @@
 					}
 				]
 			},
+			"RawOccupancyCheckEMCAL" : {
+                "active": "true",
+                "checkName": "RawOccupancyCheck",
+                "className": "o2::quality_control_modules::emcal::RawCheck",
+                "moduleName": "QcEMCAL",
+                "policy": "OnEachSeparately",
+                "detectorName": "EMC",
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "RawTaskEMCAL",
+                        "MOs": [
+                            "MinADC_EMCAL_PHYS",
+                            "MinADC_EMCAL_CAL",
+                            "MaxADC_EMCAL_PHYS",
+                            "MaxADC_EMCAL_CAL",
+                            "MeanADC_EMCAL_PHYS",
+                            "MeanADC_EMCAL_CAL",
+                            "RMSADC_EMCAL_PHYS",
+                            "RMSADC_EMCAL_CAL"
+                        ]
+                    }
+                ]
+            },
 			"CellCheckAmplitudeEMCAL": {
 				"active": "true",
 				"checkName": "CellCheckAmplitude",
@@ -226,6 +250,29 @@
 							"cellAmplitudeDCAL_PHYS",
 							"cellAmplitude_CAL",
 							"cellAmplitude_PHYS"
+						]
+					}
+				]
+			},
+			"CheckCellOccupancyEMCAL": {
+				"active": "true",
+				"checkName": "CellCheckOccupancy",
+				"className": "o2::quality_control_modules::emcal::CellCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "CellTaskEMCAL",
+						"MOs": [
+							"cellOccupancyEMC_PHYS",
+							"cellOccupancyEMCwThrBelow_PHYS",
+							"cellOccupancyEMCwThr_PHYS",
+							"cellOccupancyInt_PHYS",
+							"cellOccupancyEMC_CAL",
+							"cellOccupancyEMCwThrBelow_CAL",
+							"cellOccupancyInt_CAL"
 						]
 					}
 				]

--- a/scripts/etc/emc-qcmn-flpepn.json
+++ b/scripts/etc/emc-qcmn-flpepn.json
@@ -188,6 +188,30 @@
                     }
                 ]
             },
+            "RawOccupancyCheckEMCAL" : {
+                "active": "true",
+                "checkName": "RawOccupancyCheck",
+                "className": "o2::quality_control_modules::emcal::RawCheck",
+                "moduleName": "QcEMCAL",
+                "policy": "OnEachSeparately",
+                "detectorName": "EMC",
+                "dataSource": [
+                    {
+                        "type": "Task",
+                        "name": "RawTaskEMCAL",
+                        "MOs": [
+                            "MinADC_EMCAL_PHYS",
+                            "MinADC_EMCAL_CAL",
+                            "MaxADC_EMCAL_PHYS",
+                            "MaxADC_EMCAL_CAL",
+                            "MeanADC_EMCAL_PHYS",
+                            "MeanADC_EMCAL_CAL",
+                            "RMSADC_EMCAL_PHYS",
+                            "RMSADC_EMCAL_CAL"
+                        ]
+                    }
+                ]
+            },
             "CellCheckAmplitudeEMCAL": {
                 "active": "true",
                 "checkName": "CellCheckAmplitude",
@@ -210,6 +234,29 @@
                     }
                 ]
             },
+            "CheckCellOccupancyEMCAL": {
+				"active": "true",
+				"checkName": "CellCheckOccupancy",
+				"className": "o2::quality_control_modules::emcal::CellCheck",
+				"moduleName": "QcEMCAL",
+				"policy": "OnEachSeparately",
+				"detectorName": "EMC",
+				"dataSource": [
+					{
+						"type": "Task",
+						"name": "CellTaskEMCAL",
+						"MOs": [
+							"cellOccupancyEMC_PHYS",
+							"cellOccupancyEMCwThrBelow_PHYS",
+							"cellOccupancyEMCwThr_PHYS",
+							"cellOccupancyInt_PHYS",
+							"cellOccupancyEMC_CAL",
+							"cellOccupancyEMCwThrBelow_CAL",
+							"cellOccupancyInt_CAL"
+						]
+					}
+				]
+			},
             "RawDecodingErrorCheckEMCAL": {
                 "active": "true",
                 "className": "o2::quality_control_modules::emcal::RawErrorCheck",


### PR DESCRIPTION
Mainly used for drawing supermodule grids in the beautify
function for easy interpretation of the plots. Includes all
occupancy histograms from the raw and the cell task.