### PR TITLE
Use node-specific config files for qcmn-daq-local

### DIFF
--- a/scripts/qcmn-daq.sh
+++ b/scripts/qcmn-daq.sh
@@ -11,7 +11,7 @@ export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
 export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
 QC_GEN_CONFIG_PATH='json://'`pwd`'/etc/qcmn-daq.json'
-QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq'
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq-{{ it }}'
 QC_CONFIG_PARAM='qc_config_uri'
 
 cd ..
@@ -39,6 +39,7 @@ WF_NAME=qcmn-daq-remote
 export DPL_CONDITION_BACKEND="http://127.0.0.1:8084"
 export DPL_CONDITION_QUERY_RATE="${GEN_TOPO_EPN_CCDB_QUERY_RATE:--1}"
 DPL_PROCESSING_CONFIG_KEY_VALUES="NameConf.mCCDBServer=http://127.0.0.1:8084;"
+QC_FINAL_CONFIG_PATH='consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq'
 
 o2-qc --config $QC_GEN_CONFIG_PATH --remote -b --o2-control $WF_NAME
 

--- a/workflows/qcmn-daq-local.yaml
+++ b/workflows/qcmn-daq-local.yaml
@@ -4,7 +4,7 @@ vars:
     o2-dpl-raw-proxy -b --session default --dataspec 'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=10"' | o2-qc --config {{ qc_config_uri }} --local --host alio2-cr1-mvs01 -b | o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'x:{{ detector }}/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=10,transport=shmem"'
 defaults:
   detector: TST
-  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq"
+  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/qcmn-daq-{{ it }}"
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0


### PR DESCRIPTION
The STAGING nodes use different detector codes, thus cannot share the same QC config fil