### PR TITLE
[WIP] TRD and MCH remote workflows get 20GB shmem segment

### DIFF
--- a/workflows/mch-digits-epn.yaml
+++ b/workflows/mch-digits-epn.yaml
@@ -8,7 +8,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/mch-qcmn-epn-digits-remote.yaml
+++ b/workflows/mch-qcmn-epn-digits-remote.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/mch-qcmn-epn-full-remote.yaml
+++ b/workflows/mch-qcmn-epn-full-remote.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/mch-qcmn-epn-full-track-matching-remote.yaml
+++ b/workflows/mch-qcmn-epn-full-track-matching-remote.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/mch-qcmn-flp-digits-remote.yaml
+++ b/workflows/mch-qcmn-flp-digits-remote.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/trd-full-qcmn-epn.yaml
+++ b/workflows/trd-full-qcmn-epn.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/trd-full-qcmn-nodigits-epn.yaml
+++ b/workflows/trd-full-qcmn-nodigits-epn.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/trd-full-qcmn-nopulseheight-epn.yaml
+++ b/workflows/trd-full-qcmn-nopulseheight-epn.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/trd-full-qcmn-norawdatastats-epn.yaml
+++ b/workflows/trd-full-qcmn-norawdatastats-epn.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15

--- a/workflows/trd-full-qcmn-notracklets-epn.yaml
+++ b/workflows/trd-full-qcmn-notracklets-epn.yaml
@@ -7,7 +7,7 @@ defaults:
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
-  shm_segment_size: 10000000000
+  shm_segment_size: 20000000000
   shm_throw_bad_alloc: false
   session_id: default
   resources_monitoring: 15


### PR DESCRIPTION
this is to see if expanding the shared memory segment helps
with mitigating the Mergers becoming stuck not being able to create a message.