### PR TITLE
stfbuilder: use shm segment 2 and decrease size to 32MB

### DIFF
--- a/tasks/stfbuilder-senderoutput.yaml
+++ b/tasks/stfbuilder-senderoutput.yaml
@@ -38,6 +38,8 @@ command:
   arguments:
     - "--session=default"
     - "--transport=shmem"
+    - "--shm-segment-id=2"
+    - "--shm-segment-size=33554432"
     - "--monitoring-backend='{{ monitoring_dd_url }}'"
     - "--discovery-partition={{ environment_id }}"
     - "--discovery-endpoint={{ dd_discovery_endpoint }}"

--- a/tasks/stfbuilder.yaml
+++ b/tasks/stfbuilder.yaml
@@ -39,7 +39,7 @@ command:
   arguments:
     - "--session=default"
     - "--shm-segment-id=2"
-    - "--shm-segment-size=134217728"
+    - "--shm-segment-size=33554432"
     - "--transport=shmem"
     - "--monitoring-backend='{{ monitoring_dd_url }}'"
     - "--discovery-partition={{ environment_id }}"

--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -33,7 +33,7 @@ command:
   arguments:
     - "--session=default"
     - "--shm-segment-id=2"
-    - "--shm-segment-size=134217728"
+    - "--shm-segment-size=33554432"
     - "--transport=shmem"
     - "--input-channel-name={{ stfs_input_channel_name }}"
     - "--severity={{ fmq_severity }}"


### PR DESCRIPTION
Hi, this is just further optimizing the size of unused 'shared' shm segment. It has no impact on operation. It should be safe to put in prod.