### PR TITLE
stfsender: allow more than 250 peers for rc and dc transports

### DIFF
--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -25,6 +25,8 @@ command:
     - UCX_NET_DEVICES=mlx5_0:1 # This limits StfSender to IB interface (used as of DD v1.3.0)
     - UCX_TLS=sm,self,dc,rc    # Force dc/rc connection (used as of DD v1.4.0)
     - UCX_IB_SL=1              # Force IB SL1 with Adaptive Routing (AR)
+    - UCX_DC_MAX_NUM_EPS=512   # Allow 512 peers for DC transport
+    - UCX_RC_MAX_NUM_EPS=512   # Allow 512 peers for RC transport
     - O2_PARTITION={{ environment_id }}
   log: "{{ log_task_output }}"
   shell: true


### PR DESCRIPTION
This should be added to support partitions with more than 256 EPNs over RC/DC IB transport.  cc @lkrcal 