### PR TITLE
[WIP] MCH: updated standalone MCH tracks task configuration

### DIFF
--- a/jit/mch-qcmn-epn-full-track-matching-remote
+++ b/jit/mch-qcmn-epn-full-track-matching-remote
@@ -1,1 +1,1 @@
-o2-qc --config consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-epn-full-track-matching --remote -b
+o2-qc --config consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-remote-full-track-matching --remote -b

--- a/scripts/etc/mch-qcmn-epn-full-track-matching.json
+++ b/scripts/etc/mch-qcmn-epn-full-track-matching.json
@@ -38,7 +38,6 @@
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47790",
@@ -59,7 +58,6 @@
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47791",
@@ -80,7 +78,6 @@
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47792",
@@ -91,7 +88,7 @@
         "className": "o2::quality_control_modules::muonchambers::PhysicsTaskPreclusters",
         "moduleName": "QcMuonChambers",
         "detectorName": "MCH",
-        "cycleDurationSeconds": "360",
+        "cycleDurationSeconds": "300",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
@@ -101,7 +98,6 @@
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47794",
@@ -109,23 +105,24 @@
       },
       "MCHTracks": {
         "active": "true",
-        "className": "o2::quality_control_modules::muonchambers::TracksTask",
-        "moduleName": "QcMuonChambers",
+        "className": "o2::quality_control_modules::muon::TracksTask",
+        "moduleName": "QcMUONCommon",
         "detectorName": "MCH",
         "cycleDurationSeconds": "300",
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "tracks:MCH/TRACKS;trackrofs:MCH/TRACKROFS;trackclusters:MCH/TRACKCLUSTERS;trackdigits:MCH/CLUSTERDIGITS"
+          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/TRACKDIGITS"
         },
         "taskParameters": {
-          "maxTracksPerTF": "100"
+          "maxTracksPerTF": "600",
+          "standaloneMCHTracks": true,
+          "matchedMCHMIDTracks": false
         },
         "location": "local",
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47795",
@@ -140,47 +137,20 @@
         "maxNumberCycles": "-1",
         "dataSource": {
           "type": "direct",
-          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/TRACKDIGITS"
+          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/TRACKDIGITS;muontracks:GLO/MTC_MCHMID"
         },
         "taskParameters": {
           "maxTracksPerTF": "600",
           "standaloneMCHTracks": true,
-          "matchedMCHMIDTracks": false
+          "matchedMCHMIDTracks": true
         },
         "location": "local",
         "mergingMode": "delta",
         "localControl": "odc",
         "localMachines": [
-          "localhost",
           "epn"
         ],
         "remotePort": "47789",
-        "remoteMachine": "alio2-cr1-qc01.cern.ch"
-      },
-      "MCHStdTracks": {
-        "active": "true",
-        "className": "o2::quality_control_modules::muon::TracksTask",
-        "moduleName": "QcMUONCommon",
-        "detectorName": "GLO",
-        "cycleDurationSeconds": "300",
-        "maxNumberCycles": "-1",
-        "dataSource": {
-          "type": "direct",
-          "query": "mchtracks:MCH/TRACKS;mchtrackrofs:MCH/TRACKROFS;mchtrackclusters:MCH/TRACKCLUSTERS;mchtrackdigits:MCH/TRACKDIGITS"
-        },
-        "taskParameters": {
-          "maxTracksPerTF": "600",
-          "standaloneMCHTracks": true,
-          "matchedMCHMIDTracks": false
-        },
-        "location": "local",
-        "mergingMode": "delta",
-        "localControl": "odc",
-        "localMachines": [
-          "localhost",
-          "epn"
-        ],
-        "remotePort": "47788",
         "remoteMachine": "alio2-cr1-qc01.cern.ch"
       }
     },

--- a/scripts/mch-qcmn-epn-full-track-matching.sh
+++ b/scripts/mch-qcmn-epn-full-track-matching.sh
@@ -8,7 +8,7 @@ set -u
 source helpers.sh
 
 QC_GEN_CONFIG_PATH="json://${PWD}/etc/mch-qcmn-epn-full-track-matching.json"
-QC_FINAL_CONFIG_PATH="consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-epn-full-track-matching"
+QC_FINAL_CONFIG_PATH="consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-remote-full-track-matching"
 QC_CONFIG_PARAM="qc_config_uri"
 
 WF_NAME=mch-qcmn-epn-full-track-matching-remote

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-GLO-MUONTracks-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-GLO-MUONTracks-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHPreclusters-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHPreclusters-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHRofs-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHRofs-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHTracks-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MCHTracks-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MERGER-MCHPreclusters1l-0.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-MERGER-MCHPreclusters1l-0.yaml
@@ -128,4 +128,4 @@ command:
     - "--workflow-suffix"
     - "''"
     - "--period-timer-publish"
-    - "'360000000'"
+    - "'300000000'"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-QcTaskMCHDigits-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-QcTaskMCHDigits-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-QcTaskMCHErrors-proxy.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-MCH-QcTaskMCHErrors-proxy.yaml
@@ -140,8 +140,6 @@ command:
     - "'0'"
     - "--orbit-offset-enumeration"
     - "'0'"
-    - "--ready-state-policy"
-    - "'drain'"
     - "--start-value-enumeration"
     - "'0'"
     - "--step-value-enumeration"

--- a/tasks/mch-qcmn-epn-full-track-matching-remote-internal-dpl-clock.yaml
+++ b/tasks/mch-qcmn-epn-full-track-matching-remote-internal-dpl-clock.yaml
@@ -13,13 +13,6 @@ wants:
   cpu: 0.01
   memory: 1
 bind:
-  - name: from_internal-dpl-clock_to_GLO-MCHStdTracks-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
   - name: from_internal-dpl-clock_to_GLO-MUONTracks-proxy
     type: push
     transport: shmem
@@ -56,13 +49,6 @@ bind:
     sndBufSize: 4
     rcvBufSize: 4
   - name: from_internal-dpl-clock_to_MCH-QcTaskMCHErrors-proxy
-    type: push
-    transport: shmem
-    addressing: ipc
-    rateLogging: "{{ fmq_rate_logging }}"
-    sndBufSize: 4
-    rcvBufSize: 4
-  - name: from_internal-dpl-clock_to_GLO-MERGER-MCHStdTracks1l-0
     type: push
     transport: shmem
     addressing: ipc

--- a/workflows/mch-qcmn-epn-full-track-matching-remote.yaml
+++ b/workflows/mch-qcmn-epn-full-track-matching-remote.yaml
@@ -3,7 +3,7 @@ vars:
   dpl_command: >-
     o2-qc --config {{ qc_config_uri }} --remote -b
 defaults:
-  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-epn-full-track-matching"
+  qc_config_uri: "consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/mch-qcmn-remote-full-track-matching"
   monitoring_dpl_url: "no-op://"
   user: "flp"
   fmq_rate_logging: 0
@@ -16,25 +16,6 @@ roles:
     connect:
     task:
       load: mch-qcmn-epn-full-track-matching-remote-internal-dpl-clock
-  - name: "GLO-MCHStdTracks-proxy"
-    connect:
-    - name: from_internal-dpl-clock_to_GLO-MCHStdTracks-proxy
-      type: pull
-      transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_GLO-MCHStdTracks-proxy"
-      rateLogging: "{{ fmq_rate_logging }}"
-      sndBufSize: 4
-      rcvBufSize: 4
-    bind:
-    - name: GLO-MCHStdTracks-proxy
-      type: sub
-      transport: zeromq
-      addressing: tcp
-      rateLogging: "{{ fmq_rate_logging }}"
-      target: "tcp://*:47788"
-      rcvBufSize: 1
-    task:
-      load: mch-qcmn-epn-full-track-matching-remote-GLO-MCHStdTracks-proxy
   - name: "GLO-MUONTracks-proxy"
     connect:
     - name: from_internal-dpl-clock_to_GLO-MUONTracks-proxy
@@ -149,24 +130,6 @@ roles:
       rcvBufSize: 1
     task:
       load: mch-qcmn-epn-full-track-matching-remote-MCH-QcTaskMCHErrors-proxy
-  - name: "GLO-MERGER-MCHStdTracks1l-0"
-    connect:
-    - name: from_internal-dpl-clock_to_GLO-MERGER-MCHStdTracks1l-0
-      type: pull
-      transport: shmem
-      target: "{{ Parent().Path }}.internal-dpl-clock:from_internal-dpl-clock_to_GLO-MERGER-MCHStdTracks1l-0"
-      rateLogging: "{{ fmq_rate_logging }}"
-      sndBufSize: 4
-      rcvBufSize: 4
-    - name: from_GLO-MCHStdTracks-proxy_to_GLO-MERGER-MCHStdTracks1l-0
-      type: pull
-      transport: shmem
-      target: "{{ Parent().Path }}.GLO-MCHStdTracks-proxy:from_GLO-MCHStdTracks-proxy_to_GLO-MERGER-MCHStdTracks1l-0"
-      rateLogging: "{{ fmq_rate_logging }}"
-      sndBufSize: 4
-      rcvBufSize: 4
-    task:
-      load: mch-qcmn-epn-full-track-matching-remote-GLO-MERGER-MCHStdTracks1l-0
   - name: "GLO-MERGER-MUONTracks1l-0"
     connect:
     - name: from_internal-dpl-clock_to_GLO-MERGER-MUONTracks1l-0
@@ -308,17 +271,6 @@ roles:
       rcvBufSize: 4
     task:
       load: mch-qcmn-epn-full-track-matching-remote-qc-check-MCH-QcCheckMCHPreclusters
-  - name: "qc-check-sink-QGLO_MCHStdTracks_0"
-    connect:
-    - name: from_GLO-MERGER-MCHStdTracks1l-0_to_qc-check-sink-QGLO_MCHStdTracks_0
-      type: pull
-      transport: shmem
-      target: "{{ Parent().Path }}.GLO-MERGER-MCHStdTracks1l-0:from_GLO-MERGER-MCHStdTracks1l-0_to_qc-check-sink-QGLO_MCHStdTracks_0"
-      rateLogging: "{{ fmq_rate_logging }}"
-      sndBufSize: 4
-      rcvBufSize: 4
-    task:
-      load: mch-qcmn-epn-full-track-matching-remote-qc-check-sink-QGLO_MCHStdTracks_0
   - name: "qc-check-sink-QGLO_MUONTracks_0"
     connect:
     - name: from_GLO-MERGER-MUONTracks1l-0_to_qc-check-sink-QGLO_MUONTracks_0


### PR DESCRIPTION
- removed the duplicated MCHStdTracks task
- changed MCHTracks to use o2::quality_control_modules::muon::TracksTask
- renamed consul file to `mch-qcmn-remote-full-track-matching`
