### PR TITLE
Switch to topology generation script from updatable RPM

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -960,7 +960,7 @@ defaults:
   ###############################
   # EPN Workflows Panel
   ###############################
-  pdp_generator_script_path: /home/epn/pdp/gen_topo.sh
+  pdp_generator_script_path: /opt/alisw/el8/GenTopo/bin/gen_topo_logged.sh
   pdp_panel_mode: !public
     value: "Shifter"
     type: string


### PR DESCRIPTION
Could you please deploy this with next O2PDPSuite update. Change is transparent, currently there is already a symlink pointing from the old place to the new one.