### PR TITLE
Parametrize StfSender SHM size

### DIFF
--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -13,6 +13,7 @@ defaults:
   log_task_stdout: none
   log_task_stderr: none
   stfs_dd_region_size: 4096
+  stfs_shm_segment_size: 33554432
   _module_cmdline: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load DataDistribution Control-OCCPlugin &&
     numactl --cpunodebind=0 --preferred=0 -- StfSender
@@ -38,7 +39,7 @@ command:
   arguments:
     - "--session=default"
     - "--shm-segment-id=2"
-    - "--shm-segment-size=33554432"
+    - "--shm-segment-size={{ stfs_shm_segment_size }}"
     - "--dd-region-size={{ stfs_dd_region_size }}"
     - "--dd-region-id=3536"
     - "--transport=shmem"


### PR DESCRIPTION
@teo is there any way of using a different value for the StfSender running in the CTP readout node ?