### PR TITLE
Prevent users from using more than one CTP readout

### DIFF
--- a/tasks/readout-ctp.yaml
+++ b/tasks/readout-ctp.yaml
@@ -1,0 +1,33 @@
+name: readout-ctp # read by workflow
+defaults:
+  readout_cfg_uri: "consul-ini://{{ consul_endpoint }}/o2/components/readout/ANY/any/readout-standalone-{{ task_hostname }}"
+  user: flp
+  log_task_stdout: none
+  log_task_stderr: none
+  _module_cmdline: >-
+    source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load Readout Control-OCCPlugin &&
+    o2-readout-exe
+  _plain_cmdline: "{{ o2_install_path }}/bin/o2-readout-exe"
+control:
+  mode: direct
+wants:
+  cpu: 0.15
+  memory: 60000000000
+bind:
+  - name: readout
+    type: push
+    rateLogging: "{{ fmq_rate_logging }}"
+    addressing: ipc
+    transport: shmem
+properties: {}
+command: 
+  stdout: "{{ log_task_stdout }}"
+  stderr: "{{ log_task_stderr }}"
+  shell: true
+  env:
+    - O2_DETECTOR={{ detector }}
+    - O2_PARTITION={{ environment_id }}
+  user: "{{ user }}"
+  arguments:
+    - "{{ readout_cfg_uri }}"
+  value: "{{ len(modulepath)>0 ? _module_cmdline : _plain_cmdline }}"

--- a/tasks/readout-ctp.yaml
+++ b/tasks/readout-ctp.yaml
@@ -12,7 +12,7 @@ control:
   mode: direct
 wants:
   cpu: 0.15
-  memory: 60000000000
+  memory: 60000
 bind:
   - name: readout
     type: push

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1383,7 +1383,7 @@ roles:
         vars:
           readout_cfg_uri: '{{dd_enabled == "true" ? readout_cfg_uri_stfb : readout_cfg_uri_standalone}}'
         task:
-          load: readout
+          load: readout-ctp
       - name: "data-distribution"
         enabled: "{{dd_enabled == 'true' && (qcdd_enabled == 'false' && minimal_dpl_enabled == 'false' && dpl_workflow == 'none' && dpl_command == 'none')}}"
         roles:


### PR DESCRIPTION
...by putting a high requirement on machine memory, so two readout instances cannot fit on one node.