### PR TITLE
More STF builder data sink options

### DIFF
--- a/tasks/stfbuilder-nooutput.yaml
+++ b/tasks/stfbuilder-nooutput.yaml
@@ -13,6 +13,7 @@ defaults:
   stfb_fee_mask: "0xffff"
   stfb_enable_datasink: "false"
   stfb_datasink_dir: "/tmp"
+  stfb_datasink_filesize: "2048"
   _module_cmdline: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load DataDistribution Control-OCCPlugin &&
     StfBuilder
@@ -44,3 +45,5 @@ command:
     - "--run-type={{ stfb_dd_mode }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"

--- a/tasks/stfbuilder-nooutput.yaml
+++ b/tasks/stfbuilder-nooutput.yaml
@@ -46,4 +46,4 @@ command:
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
-    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size=' +  stfb_datasink_filesize : ' ' }}"

--- a/tasks/stfbuilder-senderoutput.yaml
+++ b/tasks/stfbuilder-senderoutput.yaml
@@ -14,6 +14,7 @@ defaults:
   stfb_fee_mask: "0xffff"
   stfb_enable_datasink: "false"
   stfb_datasink_dir: "/tmp"
+  stfb_datasink_filesize: "2048"
   _module_cmdline: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load DataDistribution Control-OCCPlugin &&
     StfBuilder
@@ -57,3 +58,5 @@ command:
     - "--run-type={{ stfb_dd_mode }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"

--- a/tasks/stfbuilder-senderoutput.yaml
+++ b/tasks/stfbuilder-senderoutput.yaml
@@ -59,4 +59,4 @@ command:
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
-    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size=' +  stfb_datasink_filesize : ' ' }}"

--- a/tasks/stfbuilder.yaml
+++ b/tasks/stfbuilder.yaml
@@ -60,4 +60,4 @@ command:
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
-    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size=' +  stfb_datasink_filesize : ' ' }}"

--- a/tasks/stfbuilder.yaml
+++ b/tasks/stfbuilder.yaml
@@ -14,6 +14,7 @@ defaults:
   stfb_fee_mask: "0xffff"
   stfb_enable_datasink: "false"
   stfb_datasink_dir: "/tmp"
+  stfb_datasink_filesize: "2048"
   _module_cmdline: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load DataDistribution Control-OCCPlugin &&
     StfBuilder
@@ -58,3 +59,5 @@ command:
     - "--run-type={{ stfb_dd_mode }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
     - "{{ stfb_enable_datasink == 'true' ? '--data-sink-dir=' +  stfb_datasink_dir : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
+    - "{{ stfb_enable_datasink == 'true' ? '--data-sink-max-file-size arg=' +  stfb_datasink_filesize : ' ' }}"


### PR DESCRIPTION
- Set number of timeframes / file to unlimited, let file
  size decide about splitting
- Add parameter for STF rawTF file size (default: 2 GB)