### PR TITLE
[FOCAL-10] Add filesink options for the sender

### DIFF
--- a/jit/foc-reconstructor
+++ b/jit/foc-reconstructor
@@ -1,4 +1,3 @@
 o2-dpl-raw-proxy -b --session default --dataspec 'x0:FOC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' \
 | o2-focal-raw-decoder-workflow  -b --session default \
-| o2-focal-event-writer-workflow -b --session default --focal-event-writer "--outfile focalevents.root" \
-| o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'x0:FOC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"'
+| o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'padlayers:FOC/PADLAYERS/0;pixelhits:FOC/PIXELHITS/0;pixelchips:FOC/PIXELCHIPS/0;triggers:FOC/TRIGGERS/0;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"'

--- a/jit/foc-reconstructor-qc
+++ b/jit/foc-reconstructor-qc
@@ -1,5 +1,4 @@
 o2-dpl-raw-proxy -b --session default --dataspec 'x0:FOC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --readout-proxy '--channel-config "name=readout-proxy,type=pull,method=connect,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"' \
 | o2-focal-raw-decoder-workflow  -b --session default \
-| o2-focal-event-writer-workflow -b --session default --focal-event-writer "--outfile focalevents.root" \
 | o2-qc -b --session default --config consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/foc-raw-qc-{{ it }} \
-| o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'x0:FOC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"'
+| o2-dpl-output-proxy --environment DPL_OUTPUT_PROXY_ORDERED=1 -b --session default --dataspec 'padlayers:FOC/PADLAYERS/0;pixelhits:FOC/PIXELHITS/0;pixelchips:FOC/PIXELCHIPS/0;triggers:FOC/TRIGGERS/0;dd:FLP/DISTSUBTIMEFRAME/0' --dpl-output-proxy '--channel-config "name=downstream,type=push,method=bind,address=ipc:///tmp/stf-pipe-0,rateLogging=1,transport=shmem"'

--- a/tasks/stfsender.yaml
+++ b/tasks/stfsender.yaml
@@ -14,6 +14,9 @@ defaults:
   log_task_stderr: none
   stfs_dd_region_size: 4096
   stfs_shm_segment_size: 33554432
+  stfs_enable_datasink: "false"
+  stfs_datasink_dir: "/tmp"
+  stfs_datasink_filesize: "2048"
   _module_cmdline: >-
     source /etc/profile.d/modules.sh && MODULEPATH={{ modulepath }} module load DataDistribution Control-OCCPlugin &&
     numactl --cpunodebind=0 --preferred=0 -- StfSender
@@ -53,3 +56,7 @@ command:
     - "--discovery-net-if={{ dd_discovery_net_if }}"
     - '{{ ddsched_enabled == "true" ? "" : "--stand-alone" }}'
     - "--shm-monitor=false"
+    - "{{ stfs_enable_datasink == 'true' ? '--data-sink-enable' : ' ' }}"
+    - "{{ stfs_enable_datasink == 'true' ? '--data-sink-dir=' +  stfs_datasink_dir : ' ' }}"
+    - "{{ stfs_enable_datasink == 'true' ? '--data-sink-max-stfs-per-file=0' : ' ' }}"
+    - "{{ stfs_enable_datasink == 'true' ? '--data-sink-max-file-size=' +  stfs_datasink_filesize : ' ' }}"


### PR DESCRIPTION
- Add filesink options for sender (allows to write output from DPL workflow to STF files)
- Change output specs in FOCAL reconstruction workflows to DPL outputs in FOCAL DPL output proxies