### PR TITLE
TPC: Add missing option in tpc-idc-direct-sac-simple-split

### DIFF
--- a/workflows/tpc-idc-direct-sac-simple-split.yaml
+++ b/workflows/tpc-idc-direct-sac-simple-split.yaml
@@ -2,6 +2,7 @@ name: tpc-idc-direct-sac-simple-split
 defaults:
   ccdb_path: "http://o2-ccdb.internal"
   tpc_sac_try_realign: 0
+  tpc_sac_threads : 1
 roles:
   - name: tpc-idc-a
     defaults:


### PR DESCRIPTION
Fix missing line in workflow