### PR TITLE
TRD add test QC workflow

### DIFF
--- a/jit/trd-full-qcmn-epn-test
+++ b/jit/trd-full-qcmn-epn-test
@@ -1,0 +1,1 @@
+o2-qc --config consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/trd-full-qcmn-test --remote -b

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -783,6 +783,7 @@ defaults:
       - none
       - qcmn-daq-remote
       - trd-full-qcmn-epn
+      - trd-full-qcmn-epn-test
     visibleif: $$qc_remote_enabled === "true"
   trd_dcs_sor_parameters: !public
     value: "{}"


### PR DESCRIPTION
Hi @knopers8 I managed to have the full configuration of the TRD in a single json file for running at P2 called `trd-full-qcmn`.
For testing new configurations I'd like to have the option in ECS to select an alternative configuration. Therefore I am adding here `trd-full-qcmn-epn-test`. Its not planned to use it in production, but it would allow us to test something new for example in staging if we add some additional checkers or trendings.