### PR TITLE
Move trg.errorcleanup role to before_GO_ERROR

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1972,7 +1972,7 @@ roles:
       - name: errorcleanup
         call:
           func: trg.Cleanup()
-          trigger: after_GO_ERROR-100
+          trigger: before_GO_ERROR
           timeout: "{{ trg_cleanup_timeout }}"
           critical: false
       - name: destroycleanup


### PR DESCRIPTION
Since in a healthy end of run sequence we perform end of trigger at before_STOP_ACTIVITY, there is no reason to perform it later in the sequence in case of going to ERROR. I confirmed with the trigger and reconstruction experts that the change is OK and I could not find any explanations why it was originally `after_GO_ERROR-100`, neither in the commit history nor jira.