### PR TITLE
Add support for QC big screen

### DIFF
--- a/jit/glo-qc-big-screen
+++ b/jit/glo-qc-big-screen
@@ -1,0 +1,1 @@
+o2-qc --config consul-json://{{ consul_endpoint }}/o2/components/qc/ANY/any/glo-qc-big-screen --remote -b

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -899,6 +899,15 @@ defaults:
     panel: "QC_Nodes_Workflows"
     index: 22
     visibleif: $$qc_remote_enabled === "true"
+  glo_big_screen_qc_enabled: !public
+    value: "false"
+    type: bool
+    label: "QC Big Screen"
+    description: "Enable/disable QC Big Screen"
+    widget: checkBox
+    panel: "QC_Nodes_Workflows"
+    index: 23
+    visibleif: $$qc_remote_enabled === "true"
   ###############################
   # TRG Panel
   ###############################
@@ -1759,6 +1768,9 @@ roles:
           - name: glo-mean-vtx-calib
             enabled: "{{ glo_mean_vtx_calib_post_proc_qc_enabled == 'true' && qc_remote_jit_enabled == 'true'}}"
             include: "{{ qc_remote_jit_enabled == 'true' ? dpl.GenerateFromUri('glo-mean-vtx-post-processing-qcmn-remote') : '' }}"
+          - name: glo-qc-big-screen
+            enabled: "{{ glo_big_screen_qc_enabled == 'true' && qc_remote_jit_enabled == 'true'}}"
+            include: "{{ qc_remote_jit_enabled == 'true' ? dpl.GenerateFromUri('glo-qc-big-screen') : '' }}"
           - name: fairmq-shmmonitor
             enabled: "{{ fmq_cleanup_enabled == 'true' && qc_remote_workflow != 'none' }}"
             task:


### PR DESCRIPTION
The QC Big Screen task creates a canvas with a summary of the detectors qualities, like this:
<img width="500" alt="image" src="https://github.com/AliceO2Group/ControlWorkflows/assets/6229237/b232d58e-a475-4501-b14e-e8e5adfb3aef">


The QC Big Screen is enabled with a new checkbox in the QC Node Wokflows panel, associated to a dedicated JIT workflow, called `glo-qc-big-screen`:
<img width="657" alt="image" src="https://github.com/AliceO2Group/ControlWorkflows/assets/6229237/5242f35f-2b8c-4449-ab81-e4b47b7bb35e">

