### PR TITLE
Add workflow for release validation

### DIFF
--- a/jit/glo-release-validation
+++ b/jit/glo-release-validation
@@ -1,0 +1,1 @@
+o2-qc --config apricot://{{ apricot_endpoint }}/o2/components/qc/ANY/any/glo-release-validation --remote --shm-metadata-msg-size {{ qc_shm_metadata_msg_size }} -b

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -922,6 +922,15 @@ defaults:
     panel: "QC_Nodes_Workflows"
     index: 25
     visibleif: $$qc_remote_enabled === "true"
+  glo_release_validation_qc_enabled: !public
+    value: "false"
+    type: bool
+    label: "Release Validation"
+    description: "Enable/disable release validation"
+    widget: checkBox
+    panel: "QC_Nodes_Workflows"
+    index: 26
+    visibleif: $$qc_remote_enabled === "true"
   ###############################
   # TRG Panel
   ###############################
@@ -1793,6 +1802,9 @@ roles:
           - name: glo-qc-data-size
             enabled: "{{ glo_data_size_qc_enabled == 'true' && qc_remote_jit_enabled == 'true'}}"
             include: "{{ qc_remote_jit_enabled == 'true' ? dpl.GenerateFromUri('glo-qc-data-size') : '' }}"
+          - name: glo-release-validation
+            enabled: "{{ glo_release_validation_qc_enabled == 'true' && qc_remote_jit_enabled == 'true'}}"
+            include: "{{ qc_remote_jit_enabled == 'true' ? dpl.GenerateFromUri('glo-release-validation') : '' }}"
           # When qc_remote_enabled is true, it will try to deploy a qc_remote_workflow for every detector in the list.
           # However if the {{detector}}_qc_remote_workflow is none, we deploy a ghost role that does nothing to preserve
           # control tree state management.// FIXME: this is probably not needed anymore


### PR DESCRIPTION
This PR adds an optional QC post-processing workflow that, when enabled, generates additional QC plots that compare a set of plots from each detector with their versions from a reference run, to simplify the validation of new software versions.

See https://its.cern.ch/jira/browse/OCTRL-922 for more details.