### PR TITLE
EMCAL: Add QC workflow configs for PbPb

### DIFF
--- a/jit/emc-qcmn-epnall-PbPb-remote
+++ b/jit/emc-qcmn-epnall-PbPb-remote
@@ -1,0 +1,1 @@
+o2-qc --config apricot://{{ apricot_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-epnall-PbPb --remote --shm-metadata-msg-size {{ qc_shm_metadata_msg_size }} -b

--- a/jit/emc-qcmn-epnall-withCTP-PbPb-remote
+++ b/jit/emc-qcmn-epnall-withCTP-PbPb-remote
@@ -1,0 +1,1 @@
+o2-qc --config apricot://{{ apricot_endpoint }}/o2/components/qc/ANY/any/emc-qcmn-epnall-withCTP-PbPb --remote --shm-metadata-msg-size {{ qc_shm_metadata_msg_size }} -b

--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -198,6 +198,8 @@ defaults:
       - emc-qcmn-epn-remote
       - emc-qcmn-epnall-remote
       - emc-qcmn-epnall-withCTP-remote
+      - emc-qcmn-epnall-PbPb-remote
+      - emc-qcmn-epnall-withCTP-PbPb-remote
       - emc-qcmn-flpepn-remote
       - qcmn-daq-remote
     visibleif: $$qc_remote_enabled === "true"


### PR DESCRIPTION
- Two configs added: emc-qcmn-epnall-PbPb for EMCal standalone runs and emc-qcmn-epnall-withCTP-PbPb for global runs with CTP