### PR TITLE
CTP: Update trg_start_timeout

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1294,7 +1294,7 @@ defaults:
   trg_ctp_emulator_timeout: "10s"
   trg_pfr_timeout: "5s"
   trg_load_timeout: "5s"
-  trg_start_timeout: "5s"
+  trg_start_timeout: "20s"
   trg_pre_start_timeout: "5s"
   trg_stop_timeout: "5s"
   trg_unload_timeout: "5s"


### PR DESCRIPTION
Updated trg_start_timeout to 20s as in rare occasions (noise cleanup) RunStart procedure on CTP side can take more than 12s.