### PR TITLE
remove testplugin call in trigger calls

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1968,12 +1968,6 @@ roles:
           trigger: before_START_ACTIVITY+10
           timeout: "{{ trg_load_timeout }}"
           critical: true
-      - name: pre-start
-        call:
-          func: testplugin.Noop()
-          trigger: after_START_ACTIVITY-200
-          timeout: "{{ trg_pre_start_timeout }}"
-          critical: false
       - name: start
         call:
           func: trg.RunStart()


### PR DESCRIPTION
This has been around since 2022, but it does nothing and was probably a placeholder for some real trigger call which never materialized.