### PR TITLE
Default installations should not call Bookkeeping plugin

### DIFF
--- a/workflows/readout-dataflow.yaml
+++ b/workflows/readout-dataflow.yaml
@@ -1338,8 +1338,8 @@ defaults:
   ###############################
   # Other variables
   ###############################
-  bookkeeping_enabled: "true"
-  bookkeeping_consuming_kafka: "false"
+  bookkeeping_enabled: "false"
+  bookkeeping_consuming_kafka: "true"
   bookkept: "true"
   ccdb_enabled: "false"
   dpl_workflow: none


### PR DESCRIPTION
Bookkeeping already migrated to use ECS core kafka events. The plugin was already disabled on staging/prod setups in consul, but we missed standard one-node installations.